### PR TITLE
Makefile adapded for pbuilder

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+DESTDIR=/usr/local/bin
+
 all:
 	cd src && $(MAKE)
 
@@ -5,7 +7,8 @@ debug:
 	cd src && $(MAKE) debug
 
 install:
-	cp bin/freebayes bin/bamleftalign /usr/local/bin/
+	install -m 0755 bin/freebayes $(DESTDIR)
+	install -m 0755 bin/bamleftalign $(DESTDIR)
 
 uninstall:
 	rm /usr/local/bin/freebayes /usr/local/bin/bamleftalign


### PR DESCRIPTION
Hi Erik,

I'm building the package for ubuntu, and I encountered the following error. When you build a package, you cannot use absolute paths in the make install, because if you do that, you'll get a permission error and the package could not be built. This is due to security reasons. 

The debian/ubuntu packaging system uses a chroot to install the package, so to make it works I had to apply this patch. Here this is explained in a more detailed way: http://wiki.debian.org/HowToPackageForDebian (ctrl+F DESTDIR).

The patch doesn't affect the "make install" in it's normal way. If you do a "make install" in a local installation, the software will install as always. But with this patch you can also specify the DESTDIR (which is what the debian/ubuntu building system does).

Would you mind to include it in your source please?

Thank you very much!
