### PR TITLE
changed git:// to https://

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,9 @@
 [submodule "vcflib"]
 	path = vcflib
-	url = git://github.com/ekg/vcflib.git
+	url = https://github.com/ekg/vcflib.git
 [submodule "bamtools"]
 	path = bamtools
-	url = git://github.com/pezmaster31/bamtools.git
+	url = https://github.com/pezmaster31/bamtools.git
 [submodule "intervaltree"]
 	path = intervaltree
-	url = git://github.com/ekg/intervaltree.git
+	url = https://github.com/ekg/intervaltree.git


### PR DESCRIPTION
I'm currently building on some machines that cannot access github on anything but https -- and I'm guessing I'm probably not the only person who will run into this problem.

This patch alters all calls to git://github.com (in the .gitmodules file) to use https://github.com

(see also https://github.com/ekg/vcflib/pull/33 )
