### PR TITLE
Fix segfault when doing regional calling with input BED file

### DIFF
--- a/src/AlleleParser.cpp
+++ b/src/AlleleParser.cpp
@@ -584,6 +584,7 @@ void AlleleParser::loadReferenceSequence(BedTarget* target, int before, int afte
     DEBUG2("loading reference subsequence " << target->seq << " from " << target->left << " - " << before << " to " << target->right + 1 << " + " << after << " + before");
     string name = reference.sequenceNameStartingWith(target->seq);
     currentSequence = uppercase(reference.getSubSequence(name, target->left - before, (target->right + 1 - target->left) + after + before));
+    preserveReferenceSequenceWindow(CACHED_REFERENCE_WINDOW);
     currentReferenceBase = currentReferenceBaseChar();
 }
 


### PR DESCRIPTION
Erik;
Thanks for all your work on dealing with recent issues. When testing the latest GitHub release I'm running into a segfault related to the fixes for #129:
```
Program received signal SIGSEGV, Segmentation fault.
0x0000000000444d6a in AlleleParser::loadReferenceSequence(BedTarget*, int, int)
()
(gdb) bt
#0  0x0000000000444d6a in AlleleParser::loadReferenceSequence(BedTarget*, int,
int) ()
#1  0x00000000004530ad in AlleleParser::toNextTarget() ()
#2  0x0000000000453ed8 in AlleleParser::toNextPosition() ()
#3  0x0000000000454780 in AlleleParser::getNextAlleles(Samples&, int) ()
#4  0x00000000004073c8 in main ()
```
Here is a small example BAM and BED file:

https://s3.amazonaws.com/chapmanb/fb_refbase_segfault.tar.gz

That reproduces with:
```
freebayes -f /path/to/GRCh37.fa -b test.bam --targets test.bed
```
This patch fixes the issues for me, although I don't know if it's optimal. I based it off the other use of `currentReferenceBaseChar`. Thanks again.