### PR TITLE
bit stricter BED processing

### DIFF
--- a/src/BedReader.cpp
+++ b/src/BedReader.cpp
@@ -33,12 +33,14 @@ vector<BedTarget> BedReader::entries(void) {
         // coordinates used internally should be in the latter, and coordinates
         // from the user in the former should be converted immediately to the
         // internal format.
-        vector<string> fields = split(line, " \t");
-        BedTarget entry(strip(fields[0]),
-                        atoi(strip(fields[1]).c_str()),
-                        atoi(strip(fields[2]).c_str()) - 1, // use inclusive format internally
-                        (fields.size() >= 4) ? strip(fields[3]) : "");
-        entries.push_back(entry);
+        vector<string> fields = split(line, "\t"); // only split on '\t' per BED spec
+        if( fields.size() > 1 ){ // skip track, browser, ect lines which are space delimited
+            BedTarget entry(strip(fields[0]),
+                            atoi(strip(fields[1]).c_str()),
+                            atoi(strip(fields[2]).c_str()) - 1, // use inclusive format internally
+                            (fields.size() >= 4) ? strip(fields[3]) : "");
+            entries.push_back(entry);
+        }
     }
 
     return entries;

--- a/test/t/01_call_variants.t
+++ b/test/t/01_call_variants.t
@@ -40,25 +40,25 @@ at_once=$(freebayes -f tiny/q.fa tiny/NA12878.chr22.tiny.bam | grep -v "^#" | wc
 is $by_region $at_once "freebayes produces the same number of calls if targeted per site or called without targets"
 
 cat >targets.bed <<EOF
-q 180 191
-q 1002 1013
-q 1811 1825
-q 1911 1922
-q 2344 2355
-q 3257 3268
-q 4443 4454
-q 5003 5014
-q 5074 5085
-q 5089 5100
-q 5632 5646
-q 6412 6423
-q 8840 8851
-q 9245 9265
-q 9785 9796
-q 10526 10537
-q 11255 11266
-q 11530 11541
-q 12119 12130
+q	180	191
+q	1002	1013
+q	1811	1825
+q	1911	1922
+q	2344	2355
+q	3257	3268
+q	4443	4454
+q	5003	5014
+q	5074	5085
+q	5089	5100
+q	5632	5646
+q	6412	6423
+q	8840	8851
+q	9245	9265
+q	9785	9796
+q	10526	10537
+q	11255	11266
+q	11530	11541
+q	12119	12130
 EOF
 
 is $(freebayes -f tiny/q.fa tiny/NA12878.chr22.tiny.bam -t targets.bed | grep -v "^#" | wc -l) $by_region "a targets bed file can be used with the same effect as running by region"


### PR DESCRIPTION
BED files are supposed to be able to have header lines like 'track', 'browser', ect.  To allow `freebayes` to process those, we can split only on `\t` (like the BED spec specifies) and just skip lines with only one field.

Not super important, but less confusing IMO.