### PR TITLE
add gVCF support

### DIFF
--- a/src/AlleleParser.cpp
+++ b/src/AlleleParser.cpp
@@ -94,17 +94,6 @@ void AlleleParser::openTraceFile(void) {
     }
 }
 
-void AlleleParser::openFailedFile(void) {
-    if (!parameters.failedFile.empty()) {
-        failedFile.open(parameters.failedFile.c_str(), ios::out);
-        DEBUG("Opening failed alleles file: " << parameters.failedFile << " ...");
-        if (!failedFile) {
-            ERROR(" unable to open failed alleles file: " << parameters.failedFile );
-            exit(1);
-        }
-    }
-}
-
 void AlleleParser::openOutputFile(void) {
     if (parameters.outputFile != "") {
         outputFile.open(parameters.outputFile.c_str(), ios::out);
@@ -456,7 +445,9 @@ string AlleleParser::vcfHeader() {
         << "##INFO=<ID=MQM,Number=A,Type=Float,Description=\"Mean mapping quality of observed alternate alleles\">" << endl
         << "##INFO=<ID=MQMR,Number=1,Type=Float,Description=\"Mean mapping quality of observed reference alleles\">" << endl
         << "##INFO=<ID=PAIRED,Number=A,Type=Float,Description=\"Proportion of observed alternate alleles which are supported by properly paired read fragments\">" << endl
-        << "##INFO=<ID=PAIREDR,Number=1,Type=Float,Description=\"Proportion of observed reference alleles which are supported by properly paired read fragments\">" << endl;
+        << "##INFO=<ID=PAIREDR,Number=1,Type=Float,Description=\"Proportion of observed reference alleles which are supported by properly paired read fragments\">" << endl
+        << "##INFO=<ID=MIN,Number=1,Type=Integer,Description=\"Minimum depth in gVCF output block.\">" << endl
+        << "##INFO=<ID=END,Number=1,Type=Integer,Description=\"Last position (inclusive) in gVCF output record.\">" << endl;
 
     // sequencing technology tags, which vary according to input data
     for (vector<string>::iterator st = sequencingTechnologies.begin(); st != sequencingTechnologies.end(); ++st) {
@@ -479,6 +470,7 @@ string AlleleParser::vcfHeader() {
         << "##FORMAT=<ID=QR,Number=1,Type=Integer,Description=\"Sum of quality of the reference observations\">" << endl
         << "##FORMAT=<ID=AO,Number=A,Type=Integer,Description=\"Alternate allele observation count\">" << endl
         << "##FORMAT=<ID=QA,Number=A,Type=Integer,Description=\"Sum of quality of the alternate observations\">" << endl
+        << "##FORMAT=<ID=MIN,Number=1,Type=Integer,Description=\"Minimum depth in gVCF output block.\">" << endl
         //<< "##FORMAT=<ID=SRF,Number=1,Type=Integer,Description=\"Number of reference observations on the forward strand\">" << endl
         //<< "##FORMAT=<ID=SRR,Number=1,Type=Integer,Description=\"Number of reference observations on the reverse strand\">" << endl
         //<< "##FORMAT=<ID=SAF,Number=1,Type=Integer,Description=\"Number of alternate observations on the forward strand\">" << endl
@@ -832,7 +824,6 @@ AlleleParser::AlleleParser(int argc, char** argv) : parameters(Parameters(argc, 
 
     // initialization
     openTraceFile();
-    openFailedFile();
     openOutputFile();
 
     loadFastaReference();

--- a/src/AlleleParser.h
+++ b/src/AlleleParser.h
@@ -226,7 +226,6 @@ public:
  
     void openBams(void);
     void openTraceFile(void);
-    void openFailedFile(void);
     void openOutputFile(void);
     void getSampleNames(void);
     void getPopulations(void);
@@ -323,7 +322,7 @@ public:
     string currentReferenceHaplotype();
 
     // output files
-    ofstream logFile, outputFile, traceFile, failedFile;
+    ofstream logFile, outputFile, traceFile;
     ostream* output;
 
     // utility

--- a/src/Makefile
+++ b/src/Makefile
@@ -61,6 +61,7 @@ OBJECTS=BedReader.o \
 		IndelAllele.o \
 		Bias.o \
 		Contamination.o \
+		NonCall.o \
 		SegfaultHandler.o \
 		../vcflib/tabixpp/tabix.o \
 		../vcflib/tabixpp/bgzf.o \
@@ -150,6 +151,9 @@ ResultData.o: ResultData.cpp ResultData.h Result.h Result.cpp Allele.h Utility.h
 
 Result.o: Result.cpp Result.h
 	$(CXX) $(CFLAGS) $(INCLUDE) -c Result.cpp
+
+NonCall.o: NonCall.cpp NonCall.h
+	$(CXX) $(CFLAGS) $(INCLUDE) -c NonCall.cpp
 
 BedReader.o: BedReader.cpp BedReader.h
 	$(CXX) $(CFLAGS) $(INCLUDE) -c BedReader.cpp

--- a/src/NonCall.cpp
+++ b/src/NonCall.cpp
@@ -1,0 +1,74 @@
+#include "NonCall.h"
+
+NonCall NonCalls::aggregateAll(void) {
+    NonCall aggregate;
+    bool first = true;
+    for (NonCalls::const_iterator nc = this->begin(); nc != this->end(); ++nc) {
+        for (map<long, map<string, NonCall> >::const_iterator p = nc->second.begin();
+             p != nc->second.end(); ++p) {
+            for (map<string, NonCall>::const_iterator s = p->second.begin();
+                 s != p->second.end(); ++s) {
+                const NonCall& nonCall = s->second;
+                aggregate.refCount += nonCall.refCount;
+                aggregate.altCount += nonCall.altCount;
+                aggregate.reflnQ += nonCall.reflnQ;
+                aggregate.altlnQ += nonCall.altlnQ;
+                if (first) {
+                    aggregate.minDepth = nonCall.refCount + nonCall.altCount;
+                    first = false;
+                } else {
+                    aggregate.minDepth = min(aggregate.minDepth, nonCall.refCount + nonCall.altCount);
+                }
+            }
+        }
+    }
+    return aggregate;
+}
+
+void NonCalls::aggregatePerSample(map<string, NonCall>& perSample) {
+    set<string> seen;
+    for (NonCalls::const_iterator nc = this->begin(); nc != this->end(); ++nc) {
+        for (map<long, map<string, NonCall> >::const_iterator p = nc->second.begin();
+             p != nc->second.end(); ++p) {
+            for (map<string, NonCall>::const_iterator s = p->second.begin();
+                 s != p->second.end(); ++s) {
+                const string& name = s->first;
+                const NonCall& nonCall = s->second;
+                NonCall& aggregate = perSample[name];
+                aggregate.refCount += nonCall.refCount;
+                aggregate.altCount += nonCall.altCount;
+                aggregate.reflnQ += nonCall.reflnQ;
+                aggregate.altlnQ += nonCall.altlnQ;
+                if (!seen.count(name)) {
+                    aggregate.minDepth = nonCall.refCount + nonCall.altCount;
+                    seen.insert(name);
+                } else {
+                    aggregate.minDepth = min(aggregate.minDepth, nonCall.refCount + nonCall.altCount);
+                }
+            }
+        }
+    }
+}
+
+void NonCalls::record(const string& seqName, long pos, const Samples& samples) {
+    map<string, NonCall>& site = (*this)[seqName][pos];
+    for (Samples::const_iterator s = samples.begin(); s != samples.end(); ++s) {
+        // tally ref and non-ref alleles
+        const string& name = s->first;
+        const Sample& sample = s->second;
+        NonCall& noncall = site[name];
+        for (Sample::const_iterator a = sample.begin(); a != sample.end(); ++a) {
+            const vector<Allele*>& alleles = a->second;
+            for (vector<Allele*>::const_iterator o = alleles.begin(); o != alleles.end(); ++o) {
+                Allele& allele = **o;
+                if (allele.isReference()) {
+                    ++noncall.refCount;
+                    noncall.reflnQ += allele.lnquality;
+                } else {
+                    ++noncall.altCount;
+                    noncall.altlnQ += allele.lnquality;
+                }
+            }
+        }
+    }
+}

--- a/src/NonCall.h
+++ b/src/NonCall.h
@@ -1,0 +1,46 @@
+#ifndef __NONCALL_H
+#define __NONCALL_H
+
+#include <string>
+#include <vector>
+#include <set>
+#include <map>
+#include <utility>
+#include "Utility.h"
+#include "Allele.h"
+#include "Sample.h"
+
+using namespace std;
+
+class NonCall {
+public:
+    NonCall(void)
+        : refCount(0)
+        , reflnQ(0)
+        , altCount(0)
+        , altlnQ(0)
+        , minDepth(0)
+
+    { }
+    NonCall(int rc, long double rq, int ac, long double aq, int mdp)
+        : refCount(rc)
+        , reflnQ(rq)
+        , altCount(ac)
+        , altlnQ(aq)
+        , minDepth(mdp)
+    { }
+    int refCount;
+    int altCount;
+    int minDepth;
+    long double reflnQ;
+    long double altlnQ;
+};
+
+class NonCalls : public map<string, map<long, map<string, NonCall> > > {
+public:
+    void record(const string& seqName, long pos, const Samples& samples);
+    NonCall aggregateAll(void);
+    void aggregatePerSample(map<string, NonCall>& perSite);
+};
+
+#endif

--- a/src/Parameters.cpp
+++ b/src/Parameters.cpp
@@ -95,13 +95,12 @@ void Parameters::usage(char** argv) {
         << "   -h --help       Prints this help dialog." << endl
         << "   --version       Prints the release number and the git commit id." << endl
         << endl
-        << "input and output:" << endl
+        << "input:" << endl
         << endl
         << "   -b --bam FILE   Add FILE to the set of BAM files to be analyzed." << endl
         << "   -L --bam-list FILE" << endl
         << "                   A file containing a list of BAM files to be analyzed." << endl
         << "   -c --stdin      Read BAM input on stdin." << endl
-        << "   -v --vcf FILE   Output VCF-format results to FILE." << endl
         << "   -f --fasta-reference FILE" << endl
         << "                   Use FILE as the reference sequence for analysis." << endl
         << "                   An index file (FILE.fai) will be created if none exists." << endl
@@ -127,10 +126,12 @@ void Parameters::usage(char** argv) {
         << "                      reference sequence, start, end, sample name, copy number" << endl
         << "                   ... for each region in each sample which does not have the" << endl
         << "                   default copy number as set by --ploidy." << endl
-        << "   --trace FILE    Output an algorithmic trace to FILE." << endl
-        << "   --failed-alleles FILE" << endl
-        << "                   Write a BED file of the analyzed positions which do not" << endl
-        << "                   pass --pvar to FILE." << endl
+        << endl
+        << "output:" << endl
+        << endl
+        << "   -v --vcf FILE   Output VCF-format results to FILE. (default: stdout)" << endl
+        << "   --gvcf" << endl
+        << "                   Write gVCF output, which indicates coverage in uncalled regions." << endl
         << "   -@ --variant-input VCF" << endl
         << "                   Use variants reported in VCF file as input to the algorithm." << endl
         << "                   Variants in this file will included in the output even if" << endl
@@ -152,12 +153,10 @@ void Parameters::usage(char** argv) {
         << "                   Report even loci which appear to be monomorphic, and report all" << endl
         << "                   considered alleles, even those which are not in called genotypes." << endl
         << "                   Loci which do not have any potential alternates have '.' for ALT." << endl
-        << endl
-        << "reporting:" << endl
-        << endl
         << "   -P --pvar N     Report sites if the probability that there is a polymorphism" << endl
         << "                   at the site is greater than N.  default: 0.0.  Note that post-" << endl
         << "                   filtering is generally recommended over the use of this parameter." << endl
+        << "   --trace FILE    Output an algorithmic trace to FILE." << endl
         << endl
         << "population model:" << endl
         << endl
@@ -378,7 +377,7 @@ Parameters::Parameters(int argc, char** argv) {
     output = "vcf";               // -v --vcf
     outputFile = "";
     traceFile = "";
-    failedFile = "";
+    gVCFout = false;
     alleleObservationBiasFile = "";
 
     // operation parameters
@@ -476,7 +475,7 @@ Parameters::Parameters(int argc, char** argv) {
             {"cnv-map", required_argument, 0, 'A'},
             {"vcf", required_argument, 0, 'v'},
             {"trace", required_argument, 0, '&'},
-            {"failed-alleles", required_argument, 0, '8'},
+            {"gvcf", no_argument, 0, '8'},
             {"use-duplicate-reads", no_argument, 0, '4'},
             {"no-partial-observations", no_argument, 0, '['},
             {"use-best-n-alleles", required_argument, 0, 'n'},
@@ -548,7 +547,7 @@ Parameters::Parameters(int argc, char** argv) {
     while (true) {
 
         int option_index = 0;
-        c = getopt_long(argc, argv, "hcO4ZKjH[0diN5a)Ik=wl6#uVXJY:b:G:M:x:@:A:f:t:r:s:v:n:B:p:m:q:R:Q:U:$:e:T:P:D:^:S:W:F:C:&:L:8:z:1:3:E:7:2:9:%:_:,:(:",
+        c = getopt_long(argc, argv, "hcO4ZKjH[0diN5a)Ik=wl6#uVXJY:b:G:M:x:@:A:f:t:r:s:v:n:B:p:m:q:R:Q:U:$:e:T:P:D:^:S:W:F:C:&:L:8z:1:3:E:7:2:9:%:_:,:(:",
                         long_options, &option_index);
 
         if (c == -1) // end of options
@@ -625,9 +624,9 @@ Parameters::Parameters(int argc, char** argv) {
             addLinesFromFile(bams, string(optarg));
             break;
 
-            // -8 --failed-alleles
+            // -8 --gvcf
         case '8':
-            failedFile = optarg;
+            gVCFout = true;
             break;
 
             // -4 --use-duplicate-reads

--- a/src/Parameters.h
+++ b/src/Parameters.h
@@ -36,7 +36,7 @@ public:
     string output;               // -v --vcf
     string outputFile;
     string traceFile;
-    string failedFile;    // -l --failed-alleles
+    bool gVCFout;    // -l --gvcf
     string variantPriorsFile;
     string haplotypeVariantFile;
     bool reportAllHaplotypeAlleles;

--- a/src/ResultData.h
+++ b/src/ResultData.h
@@ -11,6 +11,7 @@
 #include "Variant.h"
 #include "version_git.h"
 #include "Result.h"
+#include "NonCall.h"
 
 using namespace std;
 
@@ -49,7 +50,7 @@ public:
         string refbase,
         vector<Allele>& altAlleles,
         map<string, int> repeats,
-	int genotypingIterations,
+        int genotypingIterations,
         vector<string>& sampleNames,
         int coverage,
         GenotypeCombo& genotypeCombo,
@@ -58,6 +59,11 @@ public:
         map<Allele*, set<Allele*> >& partialSupport,
         map<int, vector<Genotype> >& genotypesByPloidy,
         vector<string>& sequencingTechnologies,
+        AlleleParser* parser);
+
+    vcf::Variant& gvcf(
+        vcf::Variant& var,
+        NonCalls& noncalls,
         AlleleParser* parser);
 };
 

--- a/src/Sample.h
+++ b/src/Sample.h
@@ -124,8 +124,6 @@ public:
     void setSupportedAlleles(void);
 };
 
-
-
 int countAlleles(Samples& samples);
 // using this one...
 void groupAlleles(Samples& samples, map<string, vector<Allele*> >& alleleGroups);

--- a/test/t/01_call_variants.t
+++ b/test/t/01_call_variants.t
@@ -7,7 +7,7 @@ PATH=../bin:$PATH # for freebayes
 PATH=../scripts:$PATH # for freebayes-parallel
 PATH=../vcflib/bin:$PATH # for vcf binaries used by freebayes-parallel
 
-plan tests 17
+plan tests 18
 
 is $(echo "$(comm -12 <(cat tiny/NA12878.chr22.tiny.giab.vcf | grep -v "^#" | cut -f 2 | sort) <(freebayes -f tiny/q.fa tiny/NA12878.chr22.tiny.bam | grep -v "^#" | cut -f 2 | sort) | wc -l) >= 13" | bc) 1 "variant calling recovers most of the GiAB variants in a test region"
 
@@ -104,3 +104,5 @@ is $(freebayes -f tiny/q.fa tiny/NA12878.chr22.tiny.bam | grep -v "^#" | wc -l) 
 
 
 is $(freebayes -f splice/1:883884-887618.fa splice/1:883884-887618.bam | grep ^1 | wc -l) 1 "freebayes can handle spliced reads"
+
+is $(freebayes -f tiny/q.fa tiny/NA12878.chr22.tiny.bam --gvcf | grep '<\*>' | wc -l) 20 "freebayes produces the expected number of lines of gVCF output"


### PR DESCRIPTION
When --gvcf is supplied, freebayes will output blocks for each
region that does not have a call. These have a particular format
that is not exactly the same as other records. A genotype quality
is provided, but this is just the reference quality sum adjusted
by the alternate quality sum. These are provided per-sample.
Average depth is provided across the region. Improvement of this
format is essential, and this version should stand as a
placeholder for future development!