### PR TITLE
Add support for reading SAM 1.3 CIGAR operations in bamleftalign

### DIFF
--- a/src/LeftAlign.cpp
+++ b/src/LeftAlign.cpp
@@ -44,7 +44,7 @@ bool leftAlign(BamAlignment& alignment, string& referenceSequence, bool debug) {
         unsigned int l = c->Length;
         char t = c->Type;
         cigar_before << l << t;
-        if (t == 'M') { // match or mismatch
+        if (t == 'M' || t == 'X' || t == '=') { // match or mismatch
             sp += l;
             rp += l;
         } else if (t == 'D') { // deletion
@@ -333,7 +333,7 @@ int countMismatches(BamAlignment& alignment, string referenceSequence) {
         c != alignment.CigarData.end(); ++c) {
         unsigned int l = c->Length;
         char t = c->Type;
-        if (t == 'M') { // match or mismatch
+        if (t == 'M' || t == 'X' || t == '=') { // match or mismatch
             for (int i = 0; i < l; ++i) {
                 if (alignment.QueryBases.at(rp) != referenceSequence.at(sp))
                     ++mismatches;


### PR DESCRIPTION
This is a simple change to enable bamleftalign to read BAM/SAM input with CIGAR operations from SAM 1.3 and later (specifically, "X" and "="). This patch does not change the output CIGAR format to SAM 1.3+ specifications, but it does maintain the total number of aligned bases from the input.

The following lines are example input CIGAR strings, the output from the HEAD version of bamleftalign, and the output from my patched version. The primary difference with the patch is the resolution of the "0M" operations from the current bamleftalign to non-zero operations.

Input CIGAR string with X and = operations:
`3S245=1X813=3D4=1I29=1X31=1X96=3D1=3I12=1X5=1I2=1D584=1X992=1X892=1X2=1X28=2D47=1X254=1X47=1X83=1X424=1X212=1X91=1X238=1D22=1X47=1X41=1D3=1D5=2D26=1D16=3D536=1X90=1X934=3I383=1X119=2X390=1X124=3I153=1X2=1X306=1X195=1X261=1X65=1D106=1X187=1I361=1X125=1X411=1X37=1X10=1X111=1D168=1X4I510=1X244=1X29=1X248=1D765=1X11=1X53=1I104=1X6=1X300=1X68=1X9=1X13=1X60=1X194=1X517=1X964=1X30=1X217=2I300=1X335=1X393=2D62=1X1737=1X135=2I313=1X1493=1X106=1X413=1X126=1X724=1X115=1X923=1I1=1X665=1X147=1X2048=4I19=1X322=1X705=1X238=1D370=1X175=1X25=1X246=1X290=3I13=1X966=1X1534=1X130=1X476=1D726=1D355=1X68=1X704=1X136=1X1598=1X85=1X173=1X22=2X1=1X597=1D201=1X212=3D137=1X133=1X677=1X8=1D235=1X1106=1X363=1D458=1X402=1D240=1X227=1X148=1D906=7I355=1D245=1X909=1D256=30S`

Output CIGAR string from bamleftalign HEAD:
`3S3D0M1I0M3D0M4I0M12D0M6I0M1D0M1I0M1D0M4I0M1D0M3I0M2D0M7I0M1D0M3I0M10D0M7I0M2D30S`

Output CIGAR string from bamleftalign huddlej patch:
`3S1059M3D4M1I158M3D1M3I18M1I2M1D2502M2D1403M1D112M1D3M1D5M2D26M1D16M3D1562M3I1020M3I987M1D294M1I1060M1D169M4I1034M1D831M1I2493M2I1030M2D1936M2I4220M1I2864M4I1287M1D1110M3I3123M1D726M1D3749M1D414M3D958M1D1706M1D861M1D617M1D906M7I355M1D1155M1D256M30S`