### PR TITLE
Updating VCFLIB submodule and format change

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "vcflib"]
-	path = vcflib
-	url = https://github.com/vcflib/vcflib.git
 [submodule "bamtools"]
 	path = bamtools
 	url = https://github.com/ekg/bamtools.git
@@ -13,3 +10,6 @@
 [submodule "bash-tap"]
 	path = test/bash-tap
 	url = https://github.com/illusori/bash-tap.git
+[submodule "vcflib"]
+	path = vcflib
+	url = https://github.com/vcflib/vcflib.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,6 @@
 [submodule "bash-tap"]
 	path = test/bash-tap
 	url = https://github.com/illusori/bash-tap.git
+[submodule "vcflib"]
+	path = vcflib
+	url = https://github.com/vcflib/vcflib.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "vcflib"]
 	path = vcflib
-	url = https://github.com/vcf/vcflib.git
+	url = https://github.com/vcflib/vcflib.git
 [submodule "bamtools"]
 	path = bamtools
 	url = https://github.com/ekg/bamtools.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -10,6 +10,3 @@
 [submodule "bash-tap"]
 	path = test/bash-tap
 	url = https://github.com/illusori/bash-tap.git
-[submodule "vcflib"]
-	path = vcflib
-	url = https://github.com/vcflib/vcflib.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "vcflib"]
 	path = vcflib
-	url = https://github.com/ekg/vcflib.git
+	url = https://github.com/vcf/vcflib.git
 [submodule "bamtools"]
 	path = bamtools
 	url = https://github.com/ekg/bamtools.git

--- a/scripts/freebayes-parallel
+++ b/scripts/freebayes-parallel
@@ -37,4 +37,4 @@ command=("freebayes" "$@")
 # iterate over regions using gnu parallel to dispatch jobs
 cat "$regionsfile" | parallel -k -j "$ncpus" "${command[@]}" --region {}
 ) | ../vcflib/scripts/vcffirstheader \
-    | ../vcflib/bin/vcffirstheader -w 1000 | vcfuniq # remove duplicates at region edges
+    | ../vcflib/bin/vcfstreamsort -w 1000 | vcfuniq # remove duplicates at region edges

--- a/scripts/freebayes-parallel
+++ b/scripts/freebayes-parallel
@@ -36,5 +36,5 @@ command=("freebayes" "$@")
 #$command | head -100 | grep "^#" # generate header
 # iterate over regions using gnu parallel to dispatch jobs
 cat "$regionsfile" | parallel -k -j "$ncpus" "${command[@]}" --region {}
-) | vcffirstheader \
-    | vcfstreamsort -w 1000 | vcfuniq # remove duplicates at region edges
+) | ../vcflib/scripts/vcffirstheader \
+    | ../vcflib/bin/vcffirstheader -w 1000 | vcfuniq # remove duplicates at region edges

--- a/src/AlleleParser.cpp
+++ b/src/AlleleParser.cpp
@@ -506,7 +506,7 @@ void AlleleParser::setupVCFInput(void) {
     // variant input for analysis and targeting
     if (!parameters.variantPriorsFile.empty()) {
         variantCallInputFile.open(parameters.variantPriorsFile);
-        currentVariant = new vcf::Variant(variantCallInputFile);
+        currentVariant = new vcflib::Variant(variantCallInputFile);
         usingVariantInputAlleles = true;
 
         // get sample names from VCF input file
@@ -1129,7 +1129,7 @@ void AlleleParser::updateHaplotypeBasisAlleles(long int pos, int referenceLength
                                                 pos + referenceLength + CACHED_BASIS_HAPLOTYPE_WINDOW + 1)) {
             //cerr << "the vcf line " << haplotypeVariantInputFile.line << endl;
             // get the variants in the target region
-            vcf::Variant var(haplotypeVariantInputFile);
+            vcflib::Variant var(haplotypeVariantInputFile);
             while (haplotypeVariantInputFile.getNextVariant(var)) {
                 //cerr << "input variant: " << var << endl;
 
@@ -1143,9 +1143,9 @@ void AlleleParser::updateHaplotypeBasisAlleles(long int pos, int referenceLength
                   }
                 */
 
-                map<string, vector<vcf::VariantAllele> > variants = var.parsedAlternates();
-                for (map<string, vector<vcf::VariantAllele> >::iterator a = variants.begin(); a != variants.end(); ++a) {
-                    for (vector<vcf::VariantAllele>::iterator v = a->second.begin(); v != a->second.end(); ++v) {
+                map<string, vector<vcflib::VariantAllele> > variants = var.parsedAlternates();
+                for (map<string, vector<vcflib::VariantAllele> >::iterator a = variants.begin(); a != variants.end(); ++a) {
+                    for (vector<vcflib::VariantAllele>::iterator v = a->second.begin(); v != a->second.end(); ++v) {
                         //cerr << v->ref << "/" << v->alt << endl;
                         if (v->ref != v->alt) {
                             //cerr << "basis allele " << v->position << " " << v->ref << "/" << v->alt << endl;
@@ -2128,7 +2128,7 @@ void AlleleParser::getInputVariantsInRegion(string& seq, long start, long end) {
     if (!usingVariantInputAlleles) return;
 
     // get the variants in the target region
-    vcf::Variant var(variantCallInputFile);
+    vcflib::Variant var(variantCallInputFile);
     if (!seq.empty()) {
         variantCallInputFile.setRegion(seq, start, end);
     }
@@ -2138,10 +2138,10 @@ void AlleleParser::getInputVariantsInRegion(string& seq, long start, long end) {
         long int pos = currentVariant->position - 1;
         // get alternate alleles
         bool includePreviousBaseForIndels = true;
-        map<string, vector<vcf::VariantAllele> > variantAlleles = currentVariant->parsedAlternates();
+        map<string, vector<vcflib::VariantAllele> > variantAlleles = currentVariant->parsedAlternates();
         // TODO this would be a nice option: why does it not work?
-        //map<string, vector<vcf::VariantAllele> > variantAlleles = currentVariant->flatAlternates();
-        vector< vector<vcf::VariantAllele> > orderedVariantAlleles;
+        //map<string, vector<vcflib::VariantAllele> > variantAlleles = currentVariant->flatAlternates();
+        vector< vector<vcflib::VariantAllele> > orderedVariantAlleles;
         for (vector<string>::iterator a = currentVariant->alt.begin(); a != currentVariant->alt.end(); ++a) {
             orderedVariantAlleles.push_back(variantAlleles[*a]);
         }
@@ -2149,14 +2149,14 @@ void AlleleParser::getInputVariantsInRegion(string& seq, long start, long end) {
         vector<Allele> genotypeAlleles;
         set<long int> alternatePositions;
 
-        for (vector< vector<vcf::VariantAllele> >::iterator g = orderedVariantAlleles.begin(); g != orderedVariantAlleles.end(); ++g) {
+        for (vector< vector<vcflib::VariantAllele> >::iterator g = orderedVariantAlleles.begin(); g != orderedVariantAlleles.end(); ++g) {
 
-            vector<vcf::VariantAllele>& altAllele = *g;
+            vector<vcflib::VariantAllele>& altAllele = *g;
 
             vector<Allele> alleles;
 
-            for (vector<vcf::VariantAllele>::iterator v = altAllele.begin(); v != altAllele.end(); ++v) {
-                vcf::VariantAllele& variant = *v;
+            for (vector<vcflib::VariantAllele>::iterator v = altAllele.begin(); v != altAllele.end(); ++v) {
+                vcflib::VariantAllele& variant = *v;
                 long int allelePos = variant.position - 1;
                 AlleleType type;
                 string alleleSequence = variant.alt;
@@ -2261,7 +2261,7 @@ void AlleleParser::updateInputVariants(long int pos, int referenceLength) {
         if (gotRegion) {
 
             // get the variants in the target region
-            vcf::Variant var(variantCallInputFile);
+            vcflib::Variant var(variantCallInputFile);
             bool ok;
             while (ok = variantCallInputFile.getNextVariant(*currentVariant)) {
 
@@ -2269,10 +2269,10 @@ void AlleleParser::updateInputVariants(long int pos, int referenceLength) {
                 long int pos = currentVariant->position - 1;
                 // get alternate alleles
                 bool includePreviousBaseForIndels = true;
-                map<string, vector<vcf::VariantAllele> > variantAlleles = currentVariant->parsedAlternates();
+                map<string, vector<vcflib::VariantAllele> > variantAlleles = currentVariant->parsedAlternates();
                 // TODO this would be a nice option: why does it not work?
-                //map<string, vector<vcf::VariantAllele> > variantAlleles = currentVariant->flatAlternates();
-                vector< vector<vcf::VariantAllele> > orderedVariantAlleles;
+                //map<string, vector<vcflib::VariantAllele> > variantAlleles = currentVariant->flatAlternates();
+                vector< vector<vcflib::VariantAllele> > orderedVariantAlleles;
                 for (vector<string>::iterator a = currentVariant->alt.begin(); a != currentVariant->alt.end(); ++a) {
                     orderedVariantAlleles.push_back(variantAlleles[*a]);
                 }
@@ -2280,14 +2280,14 @@ void AlleleParser::updateInputVariants(long int pos, int referenceLength) {
                 vector<Allele> genotypeAlleles;
                 set<long int> alternatePositions;
 
-                for (vector< vector<vcf::VariantAllele> >::iterator g = orderedVariantAlleles.begin(); g != orderedVariantAlleles.end(); ++g) {
+                for (vector< vector<vcflib::VariantAllele> >::iterator g = orderedVariantAlleles.begin(); g != orderedVariantAlleles.end(); ++g) {
 
-                    vector<vcf::VariantAllele>& altAllele = *g;
+                    vector<vcflib::VariantAllele>& altAllele = *g;
 
                     vector<Allele> alleles;
 
-                    for (vector<vcf::VariantAllele>::iterator v = altAllele.begin(); v != altAllele.end(); ++v) {
-                        vcf::VariantAllele& variant = *v;
+                    for (vector<vcflib::VariantAllele>::iterator v = altAllele.begin(); v != altAllele.end(); ++v) {
+                        vcflib::VariantAllele& variant = *v;
                         long int allelePos = variant.position - 1;
                         AlleleType type;
                         string alleleSequence = variant.alt;

--- a/src/AlleleParser.cpp
+++ b/src/AlleleParser.cpp
@@ -46,12 +46,12 @@ void AlleleParser::openBams(void) {
         DEBUG("Opening BAM fomat alignment input file: " << parameters.bams.front() << " ...");
     } else if (parameters.bams.size() > 1) {
         DEBUG("Opening " << parameters.bams.size() << " BAM fomat alignment input files");
-        for (vector<string>::const_iterator b = parameters.bams.begin(); 
+        for (vector<string>::const_iterator b = parameters.bams.begin();
                 b != parameters.bams.end(); ++b) {
             DEBUG2(*b);
         }
     }
-    
+
     if (parameters.useStdin) {
         if (!bamMultiReader.Open(parameters.bams)) {
             ERROR("Could not read BAM data from stdin");
@@ -271,7 +271,7 @@ void AlleleParser::getSampleNames(void) {
                        << endl
                        << "samples " << name << " and " << s->second << " map to " << readGroupID << endl
                        << endl
-                       << "As freebayes operates on a virtually merged stream of its input files," << endl 
+                       << "As freebayes operates on a virtually merged stream of its input files," << endl
                        << "it will not be possible to determine what sample an alignment belongs to" << endl
                        << "at runtime." << endl
                        << endl
@@ -333,7 +333,7 @@ void AlleleParser::getSampleNames(void) {
              //--------------------------------------------------------------------------------
            << "Warning: No sample file given, and no @RG tags found in BAM header." << endl
            << "All alignments from all input files will be assumed to come from the same" << endl
-           << "individual.  To group alignments by sample, you must add read groups and sample" << endl 
+           << "individual.  To group alignments by sample, you must add read groups and sample" << endl
            << "names to your alignments.  You can do this using ./scripts/sam_add_rg.pl in the" << endl
            << "freebayes source tree, or by specifying read groups and sample names when you" << endl
            << "prepare your sequencing data for alignment." << endl
@@ -451,7 +451,7 @@ string AlleleParser::vcfHeader() {
         << "##INFO=<ID=MQMR,Number=1,Type=Float,Description=\"Mean mapping quality of observed reference alleles\">" << endl
         << "##INFO=<ID=PAIRED,Number=A,Type=Float,Description=\"Proportion of observed alternate alleles which are supported by properly paired read fragments\">" << endl
         << "##INFO=<ID=PAIREDR,Number=1,Type=Float,Description=\"Proportion of observed reference alleles which are supported by properly paired read fragments\">" << endl
-        << "##INFO=<ID=MIN,Number=1,Type=Integer,Description=\"Minimum depth in gVCF output block.\">" << endl
+        << "##INFO=<ID=MIN_DP,Number=1,Type=Integer,Description=\"Minimum depth in gVCF output block.\">" << endl
         << "##INFO=<ID=END,Number=1,Type=Integer,Description=\"Last position (inclusive) in gVCF output record.\">" << endl;
 
     // sequencing technology tags, which vary according to input data
@@ -480,7 +480,7 @@ string AlleleParser::vcfHeader() {
         << "##FORMAT=<ID=QR,Number=1,Type=Integer,Description=\"Sum of quality of the reference observations\">" << endl
         << "##FORMAT=<ID=AO,Number=A,Type=Integer,Description=\"Alternate allele observation count\">" << endl
         << "##FORMAT=<ID=QA,Number=A,Type=Integer,Description=\"Sum of quality of the alternate observations\">" << endl
-        << "##FORMAT=<ID=MIN,Number=1,Type=Integer,Description=\"Minimum depth in gVCF output block.\">" << endl
+        << "##FORMAT=<ID=MIN_DP,Number=1,Type=Integer,Description=\"Minimum depth in gVCF output block.\">" << endl
         //<< "##FORMAT=<ID=SRF,Number=1,Type=Integer,Description=\"Number of reference observations on the forward strand\">" << endl
         //<< "##FORMAT=<ID=SRR,Number=1,Type=Integer,Description=\"Number of reference observations on the reverse strand\">" << endl
         //<< "##FORMAT=<ID=SAF,Number=1,Type=Integer,Description=\"Number of alternate observations on the forward strand\">" << endl
@@ -1132,7 +1132,7 @@ void AlleleParser::updateHaplotypeBasisAlleles(long int pos, int referenceLength
             vcf::Variant var(haplotypeVariantInputFile);
             while (haplotypeVariantInputFile.getNextVariant(var)) {
                 //cerr << "input variant: " << var << endl;
-		
+
                 // the following stanza is for parsed
                 // alternates. instead use whole haplotype calls, as
                 // alternates can be parsed prior to providing the
@@ -1241,7 +1241,7 @@ Allele AlleleParser::makeAllele(RegisteredAlignment& ra,
     // NB, if we are using haplotype basis alleles the algorithm forces
     // alleles that aren't in the haplotype basis set into the reference space
     if (type != ALLELE_REFERENCE
-        && type != ALLELE_NULL 
+        && type != ALLELE_NULL
         && !allowedHaplotypeBasisAllele(pos + 1,
                                         refSequence,
                                         readSequence)) {
@@ -1305,7 +1305,7 @@ Allele AlleleParser::makeAllele(RegisteredAlignment& ra,
         while (minEntropy > 0 && // ignore if turned off
                repeatRightBoundary - currentSequenceStart < currentSequence.size() && //guard
                entropy(currentSequence.substr(start, repeatRightBoundary - pos)) < minEntropy) {
-            //cerr << "entropy of " << entropy(currentSequence.substr(start, repeatRightBoundary - pos)) << " is too low, "; 
+            //cerr << "entropy of " << entropy(currentSequence.substr(start, repeatRightBoundary - pos)) << " is too low, ";
             //cerr << "increasing rought boundary to ";
             ++repeatRightBoundary;
             //cerr << repeatRightBoundary << endl;
@@ -1368,7 +1368,7 @@ RegisteredAlignment& AlleleParser::registerAlignment(BamAlignment& alignment, Re
                "alignment isMateMapped " << alignment.IsMateMapped() << endl <<
                "alignment isProperPair " << alignment.IsProperPair() << endl <<
                "alignment mapQual " << alignment.MapQuality << endl <<
-               "alignment sampleID " << sampleName << endl << 
+               "alignment sampleID " << sampleName << endl <<
                "alignment position " << alignment.Position << endl <<
                "alignment length " << alignment.Length << endl <<
                "alignment AlignedBases.size() " << alignment.AlignedBases.size() << endl <<
@@ -1402,7 +1402,7 @@ RegisteredAlignment& AlleleParser::registerAlignment(BamAlignment& alignment, Re
      *
      * Also, we don't store the entire undelying sequence; just the subsequence
      * that matches our current target region.
-     * 
+     *
      * As we step through a match sequence, we look for mismatches.  When we
      * see one we set a positional flag indicating the location, and we emit a
      * 'Reference' allele that stretches from the the base after the last
@@ -1532,7 +1532,7 @@ RegisteredAlignment& AlleleParser::registerAlignment(BamAlignment& alignment, Re
                                            lqual,
                                            qualp),
                                 parameters.allowComplex, parameters.maxComplexGap);
-			    
+
                         } else {
                             ra.addAllele(
                                 makeAllele(ra,
@@ -1582,7 +1582,7 @@ RegisteredAlignment& AlleleParser::registerAlignment(BamAlignment& alignment, Re
                                        lqual,
                                        qualp),
                             parameters.allowComplex, parameters.maxComplexGap);
-			
+
                     } else {
                         ra.addAllele(
                             makeAllele(ra,
@@ -1927,8 +1927,8 @@ void AlleleParser::updateAlignmentQueue(long int position,
                                         bool gettingPartials) {
 
     DEBUG2("updating alignment queue");
-    DEBUG2("currentPosition = " << position 
-           << "; currentSequenceStart = " << currentSequenceStart 
+    DEBUG2("currentPosition = " << position
+           << "; currentSequenceStart = " << currentSequenceStart
            << "; currentSequence end = " << currentSequence.size() + currentSequenceStart);
 
     // make sure we have sequence for the *first* alignment
@@ -1937,7 +1937,7 @@ void AlleleParser::updateAlignmentQueue(long int position,
     // push to the front until we get to an alignment that doesn't overlap our
     // current position or we reach the end of available alignments
     // filter input reads; only allow mapped reads with a certain quality
-    DEBUG2("currentAlignment.Position == " << currentAlignment.Position 
+    DEBUG2("currentAlignment.Position == " << currentAlignment.Position
            << ", currentAlignment.AlignedBases.size() == " << currentAlignment.AlignedBases.size()
            << ", currentPosition == " << position
            << ", currentSequenceStart == " << currentSequenceStart
@@ -2630,7 +2630,7 @@ bool AlleleParser::loadTarget(BedTarget* target) {
                     currentTarget->right + 1);
             //return false;
         } else {
-            DEBUG("set region of variant input file to " << 
+            DEBUG("set region of variant input file to " <<
                     currentTarget->seq << ":" << currentTarget->left << ".." <<
                     currentTarget->right + 1);
         }
@@ -2901,7 +2901,7 @@ bool RegisteredAlignment::fitHaplotype(int haplotypeStart, int haplotypeLength, 
     vector<Allele> newAlleles;
 
     int haplotypeEnd = haplotypeStart + haplotypeLength;
-    
+
     //if (containedAlleleTypes == ALLELE_REFERENCE) {
     //    return false;
     //}
@@ -3159,7 +3159,7 @@ void AlleleParser::buildHaplotypeAlleles(
 
         // for each non-reference allele within the haplotype length of this
         // position, adjust the length and reference sequences of the adjacent
-        // alleles 
+        // alleles
         DEBUG("fitting haplotype block " << currentPosition << " to " << currentPosition + haplotypeLength << ", " << haplotypeLength << "bp");
 
         lastHaplotypeLength = haplotypeLength;
@@ -3367,7 +3367,7 @@ void AlleleParser::buildHaplotypeAlleles(
                 (*p)->setQuality();
                 (*p)->update(haplotypeLength);
             }
-            
+
             // now add in partial observations collected from partially-overlapping reads
             if (!partialHaplotypeObservations.empty()) {
                 samples.assignPartialSupport(alleles,
@@ -3555,9 +3555,9 @@ void AlleleParser::getAlleles(Samples& samples, int allowedAlleleTypes,
         if (allowedAlleleTypes & allele.type
             && ((haplotypeLength > 1 &&
                  ((allele.type == ALLELE_REFERENCE
-                   && allele.position <= currentPosition 
+                   && allele.position <= currentPosition
                    && allele.position + allele.referenceLength >= currentPosition + haplotypeLength)
-                  || 
+                  ||
                   (allele.position == currentPosition
                    && allele.referenceLength == haplotypeLength)
                   ||
@@ -3570,7 +3570,7 @@ void AlleleParser::getAlleles(Samples& samples, int allowedAlleleTypes,
                  ((allele.type == ALLELE_REFERENCE
                    && allele.position <= currentPosition
                    && allele.position + allele.referenceLength > currentPosition)
-                  || 
+                  ||
                   (allele.position == currentPosition)))
                 ) ) {
             allele.update(haplotypeLength);
@@ -3644,10 +3644,10 @@ Allele* AlleleParser::referenceAllele(int mapQ, int baseQ) {
     string sequencingTech = "reference";
     string baseQstr = "";
     //baseQstr += qualityInt2Char(baseQ);
-    Allele* allele = new Allele(ALLELE_REFERENCE, 
+    Allele* allele = new Allele(ALLELE_REFERENCE,
                                 currentSequenceName,
                                 currentPosition,
-                                &currentPosition, 
+                                &currentPosition,
                                 &currentReferenceBase,
                                 1,
                                 currentPosition + 1,
@@ -3736,7 +3736,7 @@ vector<Allele> AlleleParser::genotypeAlleles(
 
     map<Allele, int> filteredAlleles;
 
-    DEBUG("filtering genotype alleles which are not supported by at least " << parameters.minAltCount 
+    DEBUG("filtering genotype alleles which are not supported by at least " << parameters.minAltCount
            << " observations comprising at least " << parameters.minAltFraction << " of the observations in a single individual");
     for (vector<pair<Allele, int> >::iterator p = unfilteredAlleles.begin();
          p != unfilteredAlleles.end(); ++p) {
@@ -3746,7 +3746,7 @@ vector<Allele> AlleleParser::genotypeAlleles(
         DEBUG("genotype allele: " << genotypeAllele << " qsum " << qSum);
 
         for (Samples::iterator s = samples.begin(); s != samples.end(); ++s) {
-            Sample& sample = s->second; 
+            Sample& sample = s->second;
             int alleleCount = 0;
             int qsum = 0;
             Sample::iterator c = sample.find(genotypeAllele.currentBase);
@@ -3760,10 +3760,10 @@ vector<Allele> AlleleParser::genotypeAlleles(
             }
             int observationCount = sample.observationCount();
             if (qsum >= parameters.minAltQSum
-                && alleleCount >= parameters.minAltCount 
+                && alleleCount >= parameters.minAltCount
                 && ((float) alleleCount / (float) observationCount) >= parameters.minAltFraction) {
-                DEBUG(genotypeAllele << " has support of " << alleleCount 
-                      << " in individual " << s->first << " (" << observationCount << " obs)" <<  " and fraction " 
+                DEBUG(genotypeAllele << " has support of " << alleleCount
+                      << " in individual " << s->first << " (" << observationCount << " obs)" <<  " and fraction "
                       << (float) alleleCount / (float) observationCount);
                 filteredAlleles[genotypeAllele] = qSum;
                 break;
@@ -3936,7 +3936,7 @@ map<string, int> AlleleParser::repeatCounts(long int position, const string& seq
             j += i;
             ++rightsteps;
         }
-        // if we went left and right a non-zero number of times, 
+        // if we went left and right a non-zero number of times,
         if (leftsteps + rightsteps > 1) {
             counts[seq] = leftsteps + rightsteps;
         }

--- a/src/AlleleParser.h
+++ b/src/AlleleParser.h
@@ -88,11 +88,11 @@ public:
     AlleleFilter(long unsigned int s, long unsigned int e) : start(s), end(e) {}
 
     // true of the allele is outside of our window
-    bool operator()(Allele& a) { 
+    bool operator()(Allele& a) {
         return !(start >= a.position && end < a.position + a.length);
     }
 
-    bool operator()(Allele*& a) { 
+    bool operator()(Allele*& a) {
         return !(start >= a->position && end < a->position + a->length);
     }
 
@@ -129,9 +129,9 @@ class AlleleParser {
 public:
 
     Parameters parameters; // holds operational parameters passed at program invocation
-    
+
     AlleleParser(int argc, char** argv);
-    ~AlleleParser(void); 
+    ~AlleleParser(void);
 
     vector<string> sampleList; // list of sample names, indexed by sample id
     vector<string> sampleListFromBam; // sample names drawn from BAM file
@@ -149,7 +149,7 @@ public:
     vector<string> referenceSequenceNames;
     map<int, string> referenceIDToName;
     string referenceSampleName;
-    
+
     // target regions
     vector<BedTarget> targets;
     // returns true if we are within a target
@@ -163,12 +163,12 @@ public:
     BedReader bedReader;
 
     // VCF
-    vcf::VariantCallFile variantCallFile;
-    vcf::VariantCallFile variantCallInputFile;   // input variant alleles, to target analysis
-    vcf::VariantCallFile haplotypeVariantInputFile;  // input alleles which will be used to construct haplotype alleles
+    vcflib::VariantCallFile variantCallFile;
+    vcflib::VariantCallFile variantCallInputFile;   // input variant alleles, to target analysis
+    vcflib::VariantCallFile haplotypeVariantInputFile;  // input alleles which will be used to construct haplotype alleles
 
     // input haplotype alleles
-    // 
+    //
     // as calling progresses, a window of haplotype basis alleles from the flanking sequence
     // map from starting position to length->alle
     map<long int, vector<AllelicPrimitive> > haplotypeBasisAlleles;  // this is in the current reference sequence
@@ -223,7 +223,7 @@ public:
 
     string bamHeader;
     vector<string> bamHeaderLines;
- 
+
     void openBams(void);
     void openOutputFile(void);
     void getSampleNames(void);
@@ -349,7 +349,7 @@ private:
 
     int currentRefID;
     BamAlignment currentAlignment;
-    vcf::Variant* currentVariant;
+    vcflib::Variant* currentVariant;
 
 };
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -14,9 +14,11 @@ CFLAGS=-O3 -D_FILE_OFFSET_BITS=64 -g
 
 BAMTOOLS_ROOT=../bamtools
 VCFLIB_ROOT=../vcflib
+TABIX_ROOT=$(VCFLIB_ROOT)/tabixpp
+HTSLIB_ROOT=$(TABIX_ROOT)/htslib
 
-LIBS = -L./ -L$(VCFLIB_ROOT)/tabixpp/ -L$(BAMTOOLS_ROOT)/lib -ltabix -lz -lm
-INCLUDE = -I$(BAMTOOLS_ROOT)/src -I../ttmath -I$(VCFLIB_ROOT)/src -I$(VCFLIB_ROOT)/
+LIBS = -lz -lm 
+INCLUDE = -I../ttmath -I$(BAMTOOLS_ROOT)/src/ -I$(VCFLIB_ROOT)/src/ -I$(TABIX_ROOT)/ -I$(VCFLIB_ROOT)/smithwaterman/ -I$(VCFLIB_ROOT)/multichoose/ -I$(VCFLIB_ROOT)/filevercmp/ -I$(HTSLIB_ROOT)/
 
 all: autoversion ../bin/freebayes ../bin/bamleftalign
 
@@ -37,7 +39,8 @@ gprof:
 # builds bamtools static lib, and copies into root
 $(BAMTOOLS_ROOT)/lib/libbamtools.a:
 	cd $(BAMTOOLS_ROOT) && mkdir -p build && cd build && cmake .. && $(MAKE)
-
+$(HTSLIB_ROOT)/libhts.a:
+	cd $(HTSLIB_ROOT) && make
 
 OBJECTS=BedReader.o \
 		CNV.o \
@@ -64,14 +67,15 @@ OBJECTS=BedReader.o \
 		NonCall.o \
 		SegfaultHandler.o \
 		../vcflib/tabixpp/tabix.o \
-		../vcflib/tabixpp/bgzf.o \
+		../vcflib/tabixpp/htslib/bgzf.o \
 		../vcflib/smithwaterman/SmithWatermanGotoh.o \
-		../vcflib/smithwaterman/disorder.c \
+		../vcflib/smithwaterman/disorder.cpp \
 		../vcflib/smithwaterman/LeftAlign.o \
 		../vcflib/smithwaterman/Repeats.o \
 		../vcflib/smithwaterman/IndelAllele.o \
 		Variant.o \
-		$(BAMTOOLS_ROOT)/lib/libbamtools.a
+		$(BAMTOOLS_ROOT)/lib/libbamtools.a \
+		$(HTSLIB_ROOT)/libhts.a
 
 HEADERS=multichoose.h version_git.h
 
@@ -104,7 +108,7 @@ alleles.o: alleles.cpp AlleleParser.o Allele.o
 dummy.o: dummy.cpp AlleleParser.o Allele.o
 	$(CXX) $(CFLAGS) $(INCLUDE) -c dummy.cpp
 
-freebayes.o: freebayes.cpp TryCatch.h $(BAMTOOLS_ROOT)/lib/libbamtools.a
+freebayes.o: freebayes.cpp TryCatch.h $(HTSLIB_ROOT)/libhts.a $(BAMTOOLS_ROOT)/lib/libbamtools.a
 	$(CXX) $(CFLAGS) $(INCLUDE) -c freebayes.cpp
 
 fastlz.o: fastlz.c fastlz.h
@@ -125,7 +129,7 @@ Genotype.o: Genotype.cpp Genotype.h Allele.h multipermute.h
 Ewens.o: Ewens.cpp Ewens.h
 	$(CXX) $(CFLAGS) $(INCLUDE) -c Ewens.cpp
 
-AlleleParser.o: AlleleParser.cpp AlleleParser.h multichoose.h Parameters.h $(BAMTOOLS_ROOT)/lib/libbamtools.a
+AlleleParser.o: AlleleParser.cpp AlleleParser.h multichoose.h Parameters.h $(BAMTOOLS_ROOT)/lib/libbamtools.a $(HTSLIB_ROOT)/libhts.a
 	$(CXX) $(CFLAGS) $(INCLUDE) -c AlleleParser.cpp
 
 Utility.o: Utility.cpp Utility.h Sum.h Product.h
@@ -173,7 +177,7 @@ bamleftalign.o: bamleftalign.cpp LeftAlign.cpp
 bamfiltertech.o: bamfiltertech.cpp
 	$(CXX) $(CFLAGS) $(INCLUDE) -c bamfiltertech.cpp
 
-LeftAlign.o: LeftAlign.h LeftAlign.cpp $(BAMTOOLS_ROOT)/lib/libbamtools.a
+LeftAlign.o: LeftAlign.h LeftAlign.cpp $(BAMTOOLS_ROOT)/lib/libbamtools.a $(HTSLIB_ROOT)/libhts.a
 	$(CXX) $(CFLAGS) $(INCLUDE) -c LeftAlign.cpp
 
 IndelAllele.o: IndelAllele.cpp IndelAllele.h
@@ -182,8 +186,9 @@ IndelAllele.o: IndelAllele.cpp IndelAllele.h
 Variant.o: $(VCFLIB_ROOT)/src/Variant.h $(VCFLIB_ROOT)/src/Variant.cpp
 	$(CXX) $(CFLAGS) $(INCLUDE) -c $(VCFLIB_ROOT)/src/Variant.cpp
 
-../vcflib/tabixpp/tabix.o: ../vcflib/tabixpp/tabix.hpp ../vcflib/tabixpp/tabix.cpp
-../vcflib/tabixpp/bgzf.o: ../vcflib/tabixpp/bgzf.c ../vcflib/tabixpp/bgzf.h
+../vcflib/tabixpp/tabix.o:
+	cd $(TABIX_ROOT)/ && make
+../vcflib/tabixpp/htslib/bgzf.o: ../vcflib/tabixpp/htslib/bgzf.c ../vcflib/tabixpp/htslib/htslib/bgzf.h
 	cd ../vcflib/tabixpp && $(MAKE)
 
 ../vcflib/smithwaterman/SmithWatermanGotoh.o: ../vcflib/smithwaterman/SmithWatermanGotoh.h ../vcflib/smithwaterman/SmithWatermanGotoh.cpp

--- a/src/Makefile
+++ b/src/Makefile
@@ -17,7 +17,7 @@ VCFLIB_ROOT=../vcflib
 TABIX_ROOT=$(VCFLIB_ROOT)/tabixpp
 HTSLIB_ROOT=$(TABIX_ROOT)/htslib
 
-LIBS = -lz -lm 
+LIBS = -lz -lm -lpthread
 INCLUDE = -I../ttmath -I$(BAMTOOLS_ROOT)/src/ -I$(VCFLIB_ROOT)/src/ -I$(TABIX_ROOT)/ -I$(VCFLIB_ROOT)/smithwaterman/ -I$(VCFLIB_ROOT)/multichoose/ -I$(VCFLIB_ROOT)/filevercmp/ -I$(HTSLIB_ROOT)/
 
 all: autoversion ../bin/freebayes ../bin/bamleftalign

--- a/src/ResultData.cpp
+++ b/src/ResultData.cpp
@@ -53,7 +53,7 @@ vcf::Variant& Results::vcf(
 
     // get the required size of the reference sequence
     // strip identical bases from start and/or end of alleles
-    // if bases have been stripped from the beginning, 
+    // if bases have been stripped from the beginning,
 
     // set up VCF record-wide variables
 
@@ -297,7 +297,7 @@ vcf::Variant& Results::vcf(
         long double altReadMismatchRate = (altObsCount == 0 ? 0 : altReadMismatchSum / altObsCount);
         long double altReadSNPRate = (altObsCount == 0 ? 0 : altReadSNPSum / altObsCount);
         long double altReadIndelRate = (altObsCount == 0 ? 0 : altReadIndelSum / altObsCount);
-        
+
         //var.info["XAM"].push_back(convert(altReadMismatchRate));
         //var.info["XAS"].push_back(convert(altReadSNPRate));
         //var.info["XAI"].push_back(convert(altReadIndelRate));
@@ -421,7 +421,7 @@ vcf::Variant& Results::vcf(
     // tally partial observations to get a mean coverage per bp of reference
     int haplotypeLength = refbase.size();
     int basesInObservations = 0;
-    
+
     for (map<string, vector<Allele*> >::iterator g = alleleGroups.begin(); g != alleleGroups.end(); ++g) {
         for (vector<Allele*>::iterator a = g->second.begin(); a != g->second.end(); ++a) {
             basesInObservations += (*a)->alternateSequence.size();
@@ -431,7 +431,7 @@ vcf::Variant& Results::vcf(
     for (map<Allele*, set<Allele*> >::iterator p = partialObservationSupport.begin(); p != partialObservationSupport.end(); ++p) {
         basesInObservations += p->first->alternateSequence.size();
     }
- 
+
     double depthPerBase = (double) basesInObservations / (double) haplotypeLength;
     var.info["DPB"].push_back(convert(depthPerBase));
 
@@ -671,19 +671,19 @@ vcf::Variant& Results::gvcf(
     var.format.clear();
     var.format.push_back("GQ");
     var.format.push_back("DP");
-    var.format.push_back("MIN");
+    var.format.push_back("MIN_DP");
     var.format.push_back("QR");
     var.format.push_back("QA");
-    
+
     NonCall total = nonCalls.aggregateAll();
     var.info["DP"].push_back(convert((total.refCount+total.altCount) / numSites));
-    var.info["MIN"].push_back(convert(total.minDepth));
+    var.info["MIN_DP"].push_back(convert(total.minDepth));
     // The text END field is one-based, inclusive. We proudly conflate this
     // with our zero-based, exclusive endPos.
     var.info["END"].push_back(convert(endPos));
 
     // genotype quality is 1- p(polymorphic)
-    
+
     map<string, NonCall> perSample;
     nonCalls.aggregatePerSample(perSample);
 
@@ -696,7 +696,7 @@ vcf::Variant& Results::gvcf(
         long double qual = nc.reflnQ - nc.altlnQ;
         sampleOutput["GQ"].push_back(convert(ln2phred(qual)));
         sampleOutput["DP"].push_back(convert((nc.refCount+nc.altCount) / numSites));
-        sampleOutput["MIN"].push_back(convert(nc.minDepth));
+        sampleOutput["MIN_DP"].push_back(convert(nc.minDepth));
         sampleOutput["QR"].push_back(convert(ln2phred(nc.reflnQ)));
         sampleOutput["QA"].push_back(convert(ln2phred(nc.altlnQ)));
     }

--- a/src/ResultData.cpp
+++ b/src/ResultData.cpp
@@ -5,8 +5,8 @@ using namespace std;
 
 
 
-vcf::Variant& Results::vcf(
-    vcf::Variant& var, // variant to update
+vcflib::Variant& Results::vcf(
+    vcflib::Variant& var, // variant to update
     BigFloat pHom,
     long double bestComboOddsRatio,
     //long double alleleSamplingProb,
@@ -637,8 +637,8 @@ vcf::Variant& Results::vcf(
 }
 
 
-vcf::Variant& Results::gvcf(
-    vcf::Variant& var,
+vcflib::Variant& Results::gvcf(
+    vcflib::Variant& var,
     NonCalls& nonCalls,
     AlleleParser* parser) {
 

--- a/src/ResultData.h
+++ b/src/ResultData.h
@@ -41,8 +41,8 @@ public:
         }
     }
 
-    vcf::Variant& vcf(
-        vcf::Variant& var, // variant to update
+    vcflib::Variant& vcf(
+        vcflib::Variant& var, // variant to update
         BigFloat pHom,
         long double bestComboOddsRatio,
         //long double alleleSamplingProb,
@@ -61,8 +61,8 @@ public:
         vector<string>& sequencingTechnologies,
         AlleleParser* parser);
 
-    vcf::Variant& gvcf(
-        vcf::Variant& var,
+    vcflib::Variant& gvcf(
+        vcflib::Variant& var,
         NonCalls& noncalls,
         AlleleParser* parser);
 };

--- a/src/freebayes.cpp
+++ b/src/freebayes.cpp
@@ -2,7 +2,7 @@
 // freebayes
 //
 // A bayesian genetic variant detector.
-// 
+//
 
 // standard includes
 //#include <cstdio>
@@ -59,7 +59,7 @@
     cerr << msg << endl;
 
 
-using namespace std; 
+using namespace std;
 
 // todo
 // generalize the main function to take the parameters as input
@@ -120,7 +120,7 @@ int main (int argc, char *argv[]) {
     if (parameters.output == "vcf") {
         out << parser->variantCallFile.header << endl;
     }
-            
+
     if (0 < parameters.maxCoverage) {
         srand(13);
     }
@@ -144,7 +144,7 @@ int main (int argc, char *argv[]) {
               || (parameters.gVCFchunk &&
                   nonCalls.lastPos().second - nonCalls.firstPos().second
                   > parameters.gVCFchunk))) {
-            vcf::Variant var(parser->variantCallFile);
+            vcflib::Variant var(parser->variantCallFile);
             out << results.gvcf(var, nonCalls, parser) << endl;
             nonCalls.clear();
         }
@@ -177,7 +177,7 @@ int main (int argc, char *argv[]) {
                 for (Samples::iterator s = samples.begin(); s != samples.end(); ++s) {
                     string sampleName = s->first;
                     Sample& sample = s->second;
-                    // get the coverage for this sample 
+                    // get the coverage for this sample
                     int sampleCoverage = 0;
                     for (Sample::iterator sg = sample.begin(); sg != sample.end(); ++sg) {
                         sampleCoverage += sg->second.size();
@@ -365,7 +365,7 @@ int main (int argc, char *argv[]) {
         int estimatedMinorAllelesAtLocus = max(1, (int) ceil((double) numCopiesOfLocus * estimatedMinorFrequency));
         //cerr << "estimated minor frequency " << estimatedMinorFrequency << endl;
         //cerr << "estimated minor count " << estimatedMinorAllelesAtLocus << endl;
-        
+
 
         map<string, vector<vector<SampleDataLikelihood> > > sampleDataLikelihoodsByPopulation;
         map<string, vector<vector<SampleDataLikelihood> > > variantSampleDataLikelihoodsByPopulation;
@@ -658,12 +658,12 @@ int main (int argc, char *argv[]) {
 
             // write the last gVCF record(s)
             if (parameters.gVCFout && !nonCalls.empty()) {
-                vcf::Variant var(parser->variantCallFile);
+                vcflib::Variant var(parser->variantCallFile);
                 out << results.gvcf(var, nonCalls, parser) << endl;
                 nonCalls.clear();
             }
 
-            vcf::Variant var(parser->variantCallFile);
+            vcflib::Variant var(parser->variantCallFile);
 
             out << results.vcf(
                 var,
@@ -696,7 +696,7 @@ int main (int argc, char *argv[]) {
     // write the last gVCF record
     if (parameters.gVCFout && !nonCalls.empty()) {
         Results results;
-        vcf::Variant var(parser->variantCallFile);
+        vcflib::Variant var(parser->variantCallFile);
         out << results.gvcf(var, nonCalls, parser) << endl;
         nonCalls.clear();
     }

--- a/test/Makefile
+++ b/test/Makefile
@@ -12,4 +12,4 @@ $(freebayes):
 	cd .. && $(MAKE)
 
 $(vcfuniq):
-	cd ../vcflib && $(MAKE)
+	cd ../vcflib && make clean && make


### PR DESCRIPTION

@ekg and @mlin ,

To start off, I updated the VCFLIB pointer so I could work on OSX.  This required changes to the Makefile, updating all of the namespaces for vcflib (vcf->vcflib). This also adds HTSLIB to the repository.  The DP-> DP_MIN was a minimal change.  Tests 1-6, 8-9,11-15,17-19 are passing.  The other test appear to be failing due to grep usage errors:

```
usage: grep [-abcDEFGHhIiJLlmnOoqRSsUVvwxZ] [-A num] [-B num] [-C[num]]
	[-e pattern] [-f file] [--binary-files=value] [--color=when]
	[--context[=num]] [--directories=action] [--label] [--line-buffered]
	[--null] [pattern] [file ...]
```



closes #238 
fixes #266 