### PR TITLE
Bug fix in merge 96e85182c4cd1c462cf49ca06b858da8c7b99c44.

### DIFF
--- a/src/freebayes.cpp
+++ b/src/freebayes.cpp
@@ -183,7 +183,6 @@ int main (int argc, char *argv[]) {
                         sampleCoverage += sg->second.size();
                     }
                     if (sampleCoverage <= parameters.maxCoverage) {
-                        skip = true;
                         continue;
                     }
 


### PR DESCRIPTION
We should not skip when we have *enough* coverage, rather we do not need
to downsample when we have *enough* coverage.