### PR TITLE
fixing min_depth

### DIFF
--- a/src/AlleleParser.cpp
+++ b/src/AlleleParser.cpp
@@ -2107,7 +2107,8 @@ pair<int, long int> AlleleParser::nextInputVariantPosition(void) {
             return make_pair(currentRefID, ic->first);
         } else {
             // find next chrom with input alleles
-            map<int, map<long, vector<Allele> > >::iterator nc = inputVariantAlleles.upper_bound(currentRefID);
+            map<int, map<long, vector<Allele> > >::iterator nc
+              = inputVariantAlleles.upper_bound(currentRefID);
             if (nc != inputVariantAlleles.end()) {
                 return make_pair(nc->first, nc->second.begin()->first);
             } else {
@@ -2142,20 +2143,24 @@ void AlleleParser::getInputVariantsInRegion(string& seq, long start, long end) {
         // TODO this would be a nice option: why does it not work?
         //map<string, vector<vcflib::VariantAllele> > variantAlleles = currentVariant->flatAlternates();
         vector< vector<vcflib::VariantAllele> > orderedVariantAlleles;
-        for (vector<string>::iterator a = currentVariant->alt.begin(); a != currentVariant->alt.end(); ++a) {
+        for (vector<string>::iterator a = currentVariant->alt.begin();
+          a != currentVariant->alt.end(); ++a) {
             orderedVariantAlleles.push_back(variantAlleles[*a]);
         }
 
         vector<Allele> genotypeAlleles;
         set<long int> alternatePositions;
 
-        for (vector< vector<vcflib::VariantAllele> >::iterator g = orderedVariantAlleles.begin(); g != orderedVariantAlleles.end(); ++g) {
+        for (vector< vector<vcflib::VariantAllele> >::iterator
+          g = orderedVariantAlleles.begin();
+          g != orderedVariantAlleles.end(); ++g) {
 
             vector<vcflib::VariantAllele>& altAllele = *g;
 
             vector<Allele> alleles;
 
-            for (vector<vcflib::VariantAllele>::iterator v = altAllele.begin(); v != altAllele.end(); ++v) {
+            for (vector<vcflib::VariantAllele>::iterator v = altAllele.begin();
+              v != altAllele.end(); ++v) {
                 vcflib::VariantAllele& variant = *v;
                 long int allelePos = variant.position - 1;
                 AlleleType type;

--- a/src/NonCall.cpp
+++ b/src/NonCall.cpp
@@ -4,8 +4,8 @@ NonCall NonCalls::aggregateAll(void) {
     NonCall aggregate;
     bool first = true;
     for (NonCalls::const_iterator nc = this->begin(); nc != this->end(); ++nc) {
-        for (map<long, map<string, NonCall> >::const_iterator p = nc->second.begin();
-             p != nc->second.end(); ++p) {
+        for (map<long, map<string, NonCall> >::const_iterator p
+            = nc->second.begin(); p != nc->second.end(); ++p) {
             for (map<string, NonCall>::const_iterator s = p->second.begin();
                  s != p->second.end(); ++s) {
                 const NonCall& nonCall = s->second;
@@ -13,12 +13,14 @@ NonCall NonCalls::aggregateAll(void) {
                 aggregate.altCount += nonCall.altCount;
                 aggregate.reflnQ += nonCall.reflnQ;
                 aggregate.altlnQ += nonCall.altlnQ;
+                aggregate.nCount += 1;
                 if (first) {
-                    aggregate.minDepth = nonCall.refCount + nonCall.altCount;
-                    first = false;
+                      aggregate.minDepth = nonCall.refCount + nonCall.altCount;
+                      first = false;
                 } else {
-                    aggregate.minDepth = min(aggregate.minDepth, nonCall.refCount + nonCall.altCount);
-                }
+                    aggregate.minDepth = min(aggregate.minDepth,
+                      nonCall.refCount + nonCall.altCount);
+                  }
             }
         }
     }
@@ -39,6 +41,7 @@ void NonCalls::aggregatePerSample(map<string, NonCall>& perSample) {
                 aggregate.altCount += nonCall.altCount;
                 aggregate.reflnQ += nonCall.reflnQ;
                 aggregate.altlnQ += nonCall.altlnQ;
+                aggregate.nCount += 1;
                 if (!seen.count(name)) {
                     aggregate.minDepth = nonCall.refCount + nonCall.altCount;
                     seen.insert(name);

--- a/src/NonCall.h
+++ b/src/NonCall.h
@@ -20,6 +20,7 @@ public:
         , altCount(0)
         , altlnQ(0)
         , minDepth(0)
+        , nCount(0)
 
     { }
     NonCall(int rc, long double rq, int ac, long double aq, int mdp)
@@ -32,6 +33,7 @@ public:
     int refCount;
     int altCount;
     int minDepth;
+    int nCount  ; 
     long double reflnQ;
     long double altlnQ;
 };

--- a/src/ResultData.cpp
+++ b/src/ResultData.cpp
@@ -676,8 +676,17 @@ vcflib::Variant& Results::gvcf(
     var.format.push_back("QA");
 
     NonCall total = nonCalls.aggregateAll();
+
+    /* This resets min depth to zero if nonCalls is less than numSites. */
+
+    int minDepth = total.minDepth;
+
+    if(numSites != total.nCount){
+        minDepth = 0;
+    }
+
     var.info["DP"].push_back(convert((total.refCount+total.altCount) / numSites));
-    var.info["MIN_DP"].push_back(convert(total.minDepth));
+    var.info["MIN_DP"].push_back(convert(minDepth));
     // The text END field is one-based, inclusive. We proudly conflate this
     // with our zero-based, exclusive endPos.
     var.info["END"].push_back(convert(endPos));
@@ -695,8 +704,18 @@ vcflib::Variant& Results::gvcf(
         map<string, vector<string> >& sampleOutput = var.samples[sampleName];
         long double qual = nc.reflnQ - nc.altlnQ;
         sampleOutput["GQ"].push_back(convert(ln2phred(qual)));
+
+
+      /* This resets min depth to zero if nonCalls is less than numSites. */
+
+        int minDepth = nc.minDepth;
+
+        if(numSites != nc.nCount){
+            minDepth = 0;
+        }
+
         sampleOutput["DP"].push_back(convert((nc.refCount+nc.altCount) / numSites));
-        sampleOutput["MIN_DP"].push_back(convert(nc.minDepth));
+        sampleOutput["MIN_DP"].push_back(convert(minDepth));
         sampleOutput["QR"].push_back(convert(ln2phred(nc.reflnQ)));
         sampleOutput["QA"].push_back(convert(ln2phred(nc.altlnQ)));
     }


### PR DESCRIPTION
Summing noncall refCount and altCount is correct to get DP (average depth over gvcf block).  However, zero coverage sites need to be considered for the MIN_DP.  If numSites is greater than the number of noncalls we know there is a site with no coverage.  The INFO and GENOTYPE fields have been updated.

Solving #239 via @mlin 

