### PR TITLE
Allow compilation of bamtools with nodejs support

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,11 @@ Will build the executable freebayes, as well as the utilities bamfiltertech and
 bamleftalign.  These executables can be found in the `bin/` directory in the 
 repository.
 
+If you are planning to run freebayes in a NodeJS environment, Bamtools should be
+compiled with NodeJS support.
+
+    make BAMTOOLS_ARGS="-DEnableNodeJS=true"
+
 Users may wish to install to e.g. /usr/local/bin (default), which is 
 accomplished via
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -38,7 +38,7 @@ gprof:
 
 # builds bamtools static lib, and copies into root
 $(BAMTOOLS_ROOT)/lib/libbamtools.a:
-	cd $(BAMTOOLS_ROOT) && mkdir -p build && cd build && cmake .. && $(MAKE)
+	cd $(BAMTOOLS_ROOT) && mkdir -p build && cd build && cmake $(BAMTOOLS_ARGS) .. && $(MAKE)
 $(HTSLIB_ROOT)/libhts.a:
 	cd $(HTSLIB_ROOT) && make
 


### PR DESCRIPTION
Possible fix to #313 
