### PR TITLE
replace FORMAT/DPR annotation by FORMAT/AD

### DIFF
--- a/src/AlleleParser.cpp
+++ b/src/AlleleParser.cpp
@@ -378,7 +378,7 @@ string AlleleParser::vcfHeader() {
 
     stringstream headerss;
     headerss
-        << "##fileformat=VCFv4.1" << endl
+        << "##fileformat=VCFv4.2" << endl
         << "##fileDate=" << dateStr() << endl
         << "##source=freeBayes " << VERSION_GIT << endl
         << "##reference=" << reference.filename << endl;
@@ -503,7 +503,7 @@ string AlleleParser::vcfHeader() {
         << "##FORMAT=<ID=GL,Number=G,Type=Float,Description=\"Genotype Likelihood, log10-scaled likelihoods of the data given the called genotype for each possible genotype generated from the reference and alternate alleles given the sample ploidy\">" << endl
 	//<< "##FORMAT=<ID=GLE,Number=1,Type=String,Description=\"Genotype Likelihood Explicit, same as GL, but with tags to indicate the specific genotype.  For instance, 0^-75.22|1^-223.42|0/0^-323.03|1/0^-99.29|1/1^-802.53 represents both haploid and diploid genotype likilehoods in a biallelic context\">" << endl
         << "##FORMAT=<ID=DP,Number=1,Type=Integer,Description=\"Read Depth\">" << endl
-        << "##FORMAT=<ID=DPR,Number=A,Type=Integer,Description=\"Number of observation for each allele\">" << endl
+        << "##FORMAT=<ID=AD,Number=R,Type=Integer,Description=\"Number of observation for each allele\">" << endl
         << "##FORMAT=<ID=RO,Number=1,Type=Integer,Description=\"Reference allele observation count\">" << endl
         << "##FORMAT=<ID=QR,Number=1,Type=Integer,Description=\"Sum of quality of the reference observations\">" << endl
         << "##FORMAT=<ID=AO,Number=A,Type=Integer,Description=\"Alternate allele observation count\">" << endl

--- a/src/ResultData.cpp
+++ b/src/ResultData.cpp
@@ -76,7 +76,7 @@ vcflib::Variant& Results::vcf(
     if (parameters.calculateMarginals) var.format.push_back("GQ");
     // XXX
     var.format.push_back("DP");
-    var.format.push_back("DPR");
+    var.format.push_back("AD");
     var.format.push_back("RO");
     var.format.push_back("QR");
     var.format.push_back("AO");
@@ -519,7 +519,7 @@ vcflib::Variant& Results::vcf(
             }
 
             sampleOutput["DP"].push_back(convert(sample.observationCount()));
-            sampleOutput["DPR"].push_back(convert(sample.observationCount()));
+            sampleOutput["AD"].push_back(convert(sample.observationCount(refbase)));
             sampleOutput["RO"].push_back(convert(sample.observationCount(refbase)));
             sampleOutput["QR"].push_back(convert(sample.qualSum(refbase)));
 
@@ -527,7 +527,7 @@ vcflib::Variant& Results::vcf(
                 Allele& altAllele = *aa;
                 string altbase = altAllele.base();
                 sampleOutput["AO"].push_back(convert(sample.observationCount(altbase)));
-                sampleOutput["DPR"].push_back(convert(sample.observationCount(altbase)));
+                sampleOutput["AD"].push_back(convert(sample.observationCount(altbase)));
                 sampleOutput["QA"].push_back(convert(sample.qualSum(altbase)));
             }
 


### PR DESCRIPTION
DPR is mislabeled as a `Number=A` field, but writing out `Number=R` values.
Also, as @nh13 noticed, the REF allele count was wrong anyway -
printing the total depth rather than the REF depth.

Replace by FORMAT/AD which is a Number=R field now defined in the spec. Also
need to bump the VCF version to 4.2 (`Number=R` was introduced in 4.2, but AD in 4.3)

Fixes #267
