### PR TITLE
Improved build on OSX, update to lighter-weight SeqLib

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
 all: vcflib/Makefile log
 	cd src && $(MAKE)
 
+wbamtools: vcflib/Makefile log
+	cd src && $(MAKE) -f Makefile.bamtools
+
 log: src/version_git.h
 	wget -q http://hypervolu.me/freebayes/build/$(shell cat src/version_git.h | grep v | cut -f 3 -d\  | sed s/\"//g) &
 

--- a/README.md
+++ b/README.md
@@ -93,7 +93,6 @@ Luckily, if you have access to https:// on port 443, then you can use this
 ## Compilation
 
 FreeBayes requires g++ and the standard C and C++ development libraries.
-Additionally, cmake is required for building the BamTools API.
 
     make
 
@@ -106,6 +105,9 @@ accomplished via
 
     sudo make install
 
+Users can optionally build with [BamTools](https://github.com/pezmaster31/bamtools) instead of [SeqLib](https://github.com/walaj/SeqLib). Building with BamTools requires CMake.
+
+    make wbamtools
 
 ## Usage
 

--- a/src/Allele.cpp
+++ b/src/Allele.cpp
@@ -180,6 +180,7 @@ const short Allele::currentQuality(void) const {
             return quality;
             break;
     }
+    return 0;
 }
 
 const long double Allele::lncurrentQuality(void) const {

--- a/src/AlleleParser.cpp
+++ b/src/AlleleParser.cpp
@@ -2040,7 +2040,7 @@ void AlleleParser::updateAlignmentQueue(long int position,
 #ifdef HAVE_BAMTOOLS	    
             if (!currentAlignment.GetTag("RG", readGroup)) {
 #else
-	    readGroup = currentAlignment.GetZTag("RG");
+	      currentAlignment.GetZTag("RG", readGroup);
 	    if (readGroup.empty()) {
 #endif
                 if (!oneSampleAnalysis) {

--- a/src/Fasta.cpp
+++ b/src/Fasta.cpp
@@ -87,6 +87,7 @@ ostream& operator<<(ostream& output, FastaIndex& fastaIndex) {
     for( vector<FastaIndexEntry>::iterator fit = sortedIndex.begin(); fit != sortedIndex.end(); ++fit) {
         output << *fit << endl;
     }
+    return output;
 }
 
 void FastaIndex::indexReference(string refname) {

--- a/src/LeftAlign.h
+++ b/src/LeftAlign.h
@@ -94,7 +94,7 @@ using namespace BamTools;
 #define CIGTYPE Type()
 #define ADDCIGAR add
 #define CIGOP SeqLib::CigarField
-#define FILLREADGROUP(rg, align) (rg) = (align).GetZTag("RG")
+#define FILLREADGROUP(rg, align) (align).GetZTag("RG", rg)
 #define GETHEADERTEXT HeaderConcat()
 #include "SeqLib/BamReader.h"
 #include "SeqLib/BamWriter.h"

--- a/src/Makefile
+++ b/src/Makefile
@@ -30,16 +30,16 @@ INCLUDE = -I../ttmath -I$(VCFLIB_ROOT)/src/ -I$(TABIX_ROOT)/ -I$(VCFLIB_ROOT)/sm
 all: autoversion ../bin/freebayes ../bin/bamleftalign
 
 static:
-	$(MAKE) CFLAGS="$(CFLAGS) -static" all
+	$(MAKE) CXXFLAGS="$(CXXFLAGS) -static" all
 
 debug:
-	$(MAKE) CFLAGS="$(CFLAGS) -D VERBOSE_DEBUG -g -rdynamic" all
+	$(MAKE) CXXFLAGS="$(CXXFLAGS) -D VERBOSE_DEBUG -g -rdynamic" all
 
 profiling:
 	$(MAKE) CFLAGS="$(CFLAGS) -g" all
 
 gprof:
-	$(MAKE) CFLAGS="$(CFLAGS) -pg" all
+	$(MAKE) CXXFLAGS="$(CXXFLAGS) -pg" all
 
 .PHONY: all static debug profiling gprof
 
@@ -91,109 +91,109 @@ HEADERS=multichoose.h version_git.h
 # executables
 
 freebayes ../bin/freebayes: freebayes.o $(OBJECTS) $(HEADERS)
-	$(CXX) $(CFLAGS) $(INCLUDE) freebayes.o $(OBJECTS) -o ../bin/freebayes $(LIBS)
+	$(CXX) $(CXXFLAGS) $(INCLUDE) freebayes.o $(OBJECTS) -o ../bin/freebayes $(LIBS)
 
 alleles ../bin/alleles: alleles.o $(OBJECTS) $(HEADERS)
-	$(CXX) $(CFLAGS) $(INCLUDE) alleles.o $(OBJECTS) -o ../bin/alleles $(LIBS)
+	$(CXX) $(CXXFLAGS) $(INCLUDE) alleles.o $(OBJECTS) -o ../bin/alleles $(LIBS)
 
 dummy ../bin/dummy: dummy.o $(OBJECTS) $(HEADERS)
-	$(CXX) $(CFLAGS) $(INCLUDE) dummy.o $(OBJECTS) -o ../bin/dummy $(LIBS)
+	$(CXX) $(CXXFLAGS) $(INCLUDE) dummy.o $(OBJECTS) -o ../bin/dummy $(LIBS)
 
 bamleftalign ../bin/bamleftalign: $(SEQLIB_ROOT)/src/libseqlib.a $(SEQLIB_ROOT)/htslib/libhts.a bamleftalign.o Fasta.o LeftAlign.o IndelAllele.o split.o
-	$(CXX) $(CFLAGS) $(INCLUDE) bamleftalign.o Fasta.o Utility.o LeftAlign.o IndelAllele.o split.o $(SEQLIB_ROOT)/src/libseqlib.a $(SEQLIB_ROOT)/htslib/libhts.a -o ../bin/bamleftalign $(LIBS)
+	$(CXX) $(CXXFLAGS) $(INCLUDE) bamleftalign.o Fasta.o Utility.o LeftAlign.o IndelAllele.o split.o $(SEQLIB_ROOT)/src/libseqlib.a $(SEQLIB_ROOT)/htslib/libhts.a -o ../bin/bamleftalign $(LIBS)
 
 bamfiltertech ../bin/bamfiltertech: $(SEQLIB_ROOT)/src/libseqlib.a $(SEQLIB_ROOT)/htslib/libhts.a bamfiltertech.o $(OBJECTS) $(HEADERS)
-	$(CXX) $(CFLAGS) $(INCLUDE) bamfiltertech.o $(OBJECTS) -o ../bin/bamfiltertech $(LIBS)
+	$(CXX) $(CXXFLAGS) $(INCLUDE) bamfiltertech.o $(OBJECTS) -o ../bin/bamfiltertech $(LIBS)
 
 
 # objects
 
 Fasta.o: Fasta.cpp Utility.o
-	$(CXX) $(CFLAGS) $(INCLUDE) -c Fasta.cpp
+	$(CXX) $(CXXFLAGS) $(INCLUDE) -c Fasta.cpp
 
 alleles.o: alleles.cpp AlleleParser.o Allele.o
-	$(CXX) $(CFLAGS) $(INCLUDE) -c alleles.cpp
+	$(CXX) $(CXXFLAGS) $(INCLUDE) -c alleles.cpp
 
 dummy.o: dummy.cpp AlleleParser.o Allele.o
-	$(CXX) $(CFLAGS) $(INCLUDE) -c dummy.cpp
+	$(CXX) $(CXXFLAGS) $(INCLUDE) -c dummy.cpp
 
 freebayes.o: freebayes.cpp TryCatch.h $(HTSLIB_ROOT)/libhts.a 
-	$(CXX) $(CFLAGS) $(INCLUDE) -c freebayes.cpp
+	$(CXX) $(CXXFLAGS) $(INCLUDE) -c freebayes.cpp
 
 fastlz.o: fastlz.c fastlz.h
 	$(C) $(CFLAGS) $(INCLUDE) -c fastlz.c	
 
 Parameters.o: Parameters.cpp Parameters.h Version.h
-	$(CXX) $(CFLAGS) $(INCLUDE) -c Parameters.cpp
+	$(CXX) $(CXXFLAGS) $(INCLUDE) -c Parameters.cpp
 
 Allele.o: Allele.cpp Allele.h multichoose.h Genotype.h
-	$(CXX) $(CFLAGS) $(INCLUDE) -c Allele.cpp
+	$(CXX) $(CXXFLAGS) $(INCLUDE) -c Allele.cpp
 
 Sample.o: Sample.cpp Sample.h
-	$(CXX) $(CFLAGS) $(INCLUDE) -c Sample.cpp
+	$(CXX) $(CXXFLAGS) $(INCLUDE) -c Sample.cpp
 
 Genotype.o: Genotype.cpp Genotype.h Allele.h multipermute.h
-	$(CXX) $(CFLAGS) $(INCLUDE) -c Genotype.cpp
+	$(CXX) $(CXXFLAGS) $(INCLUDE) -c Genotype.cpp
 
 Ewens.o: Ewens.cpp Ewens.h
-	$(CXX) $(CFLAGS) $(INCLUDE) -c Ewens.cpp
+	$(CXX) $(CXXFLAGS) $(INCLUDE) -c Ewens.cpp
 
 AlleleParser.o: AlleleParser.cpp AlleleParser.h multichoose.h Parameters.h $(HTSLIB_ROOT)/libhts.a
-	$(CXX) $(CFLAGS) $(INCLUDE) -c AlleleParser.cpp
+	$(CXX) $(CXXFLAGS) $(INCLUDE) -c AlleleParser.cpp
 
 Utility.o: Utility.cpp Utility.h Sum.h Product.h
-	$(CXX) $(CFLAGS) $(INCLUDE) -c Utility.cpp
+	$(CXX) $(CXXFLAGS) $(INCLUDE) -c Utility.cpp
 
 SegfaultHandler.o: SegfaultHandler.cpp SegfaultHandler.h
-	$(CXX) $(CFLAGS) $(INCLUDE) -c SegfaultHandler.cpp
+	$(CXX) $(CXXFLAGS) $(INCLUDE) -c SegfaultHandler.cpp
 
 Dirichlet.o: Dirichlet.h Dirichlet.cpp Sum.h Product.h
-	$(CXX) $(CFLAGS) $(INCLUDE) -c Dirichlet.cpp
+	$(CXX) $(CXXFLAGS) $(INCLUDE) -c Dirichlet.cpp
 
 Multinomial.o: Multinomial.h Multinomial.cpp Sum.h Product.h Utility.h
-	$(CXX) $(CFLAGS) $(INCLUDE) -c Multinomial.cpp
+	$(CXX) $(CXXFLAGS) $(INCLUDE) -c Multinomial.cpp
 
 DataLikelihood.o: DataLikelihood.cpp DataLikelihood.h Sum.h Product.h
-	$(CXX) $(CFLAGS) $(INCLUDE) -c DataLikelihood.cpp
+	$(CXX) $(CXXFLAGS) $(INCLUDE) -c DataLikelihood.cpp
 
 Marginals.o: Marginals.cpp Marginals.h
-	$(CXX) $(CFLAGS) $(INCLUDE) -c Marginals.cpp
+	$(CXX) $(CXXFLAGS) $(INCLUDE) -c Marginals.cpp
 
 ResultData.o: ResultData.cpp ResultData.h Result.h Result.cpp Allele.h Utility.h Genotype.h AlleleParser.h Version.h
-	$(CXX) $(CFLAGS) $(INCLUDE) -c ResultData.cpp
+	$(CXX) $(CXXFLAGS) $(INCLUDE) -c ResultData.cpp
 
 Result.o: Result.cpp Result.h
-	$(CXX) $(CFLAGS) $(INCLUDE) -c Result.cpp
+	$(CXX) $(CXXFLAGS) $(INCLUDE) -c Result.cpp
 
 NonCall.o: NonCall.cpp NonCall.h
-	$(CXX) $(CFLAGS) $(INCLUDE) -c NonCall.cpp
+	$(CXX) $(CXXFLAGS) $(INCLUDE) -c NonCall.cpp
 
 BedReader.o: BedReader.cpp BedReader.h
-	$(CXX) $(CFLAGS) $(INCLUDE) -c BedReader.cpp
+	$(CXX) $(CXXFLAGS) $(INCLUDE) -c BedReader.cpp
 
 CNV.o: CNV.cpp CNV.h
-	$(CXX) $(CFLAGS) $(INCLUDE) -c CNV.cpp
+	$(CXX) $(CXXFLAGS) $(INCLUDE) -c CNV.cpp
 
 Bias.o: Bias.cpp Bias.h
-	$(CXX) $(CFLAGS) $(INCLUDE) -c Bias.cpp
+	$(CXX) $(CXXFLAGS) $(INCLUDE) -c Bias.cpp
 
 split.o: split.h split.cpp
-	$(CXX) $(CFLAGS) $(INCLUDE) -c split.cpp
+	$(CXX) $(CXXFLAGS) $(INCLUDE) -c split.cpp
 
 bamleftalign.o: bamleftalign.cpp LeftAlign.cpp
-	$(CXX) $(CFLAGS) $(INCLUDE) -c bamleftalign.cpp
+	$(CXX) $(CXXFLAGS) $(INCLUDE) -c bamleftalign.cpp
 
 bamfiltertech.o: bamfiltertech.cpp
-	$(CXX) $(CFLAGS) $(INCLUDE) -c bamfiltertech.cpp
+	$(CXX) $(CXXFLAGS) $(INCLUDE) -c bamfiltertech.cpp
 
 LeftAlign.o: LeftAlign.h LeftAlign.cpp $(HTSLIB_ROOT)/libhts.a
-	$(CXX) $(CFLAGS) $(INCLUDE) -c LeftAlign.cpp
+	$(CXX) $(CXXFLAGS) $(INCLUDE) -c LeftAlign.cpp
 
 IndelAllele.o: IndelAllele.cpp IndelAllele.h
-	$(CXX) $(CFLAGS) $(INCLUDE) -c IndelAllele.cpp
+	$(CXX) $(CXXFLAGS) $(INCLUDE) -c IndelAllele.cpp
 
 Variant.o: $(VCFLIB_ROOT)/src/Variant.h $(VCFLIB_ROOT)/src/Variant.cpp
-	$(CXX) $(CFLAGS) $(INCLUDE) -c $(VCFLIB_ROOT)/src/Variant.cpp
+	$(CXX) $(CXXFLAGS) $(INCLUDE) -c $(VCFLIB_ROOT)/src/Variant.cpp
 
 ../vcflib/tabixpp/tabix.o:
 	cd $(TABIX_ROOT)/ && make

--- a/src/Makefile
+++ b/src/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 
 # Compiler
-CXX=g++
+CXX=g++ ${CXXFLAGS}
 C=gcc
 
 export CXXFLAGS
@@ -16,6 +16,7 @@ export LDFLAGS
 export LIBFLAGS
 
 # Compiler flags
+
 CFLAGS=-O3 -D_FILE_OFFSET_BITS=64 -g
 #CFLAGS=-O3 -static -D VERBOSE_DEBUG  # enables verbose debugging via --debug2
 

--- a/src/Makefile.bamtools
+++ b/src/Makefile.bamtools
@@ -13,13 +13,12 @@ CFLAGS=-O3 -D_FILE_OFFSET_BITS=64 -g
 #CFLAGS=-O3 -static -D VERBOSE_DEBUG  # enables verbose debugging via --debug2
 
 BAMTOOLS_ROOT=../bamtools
-SEQLIB_ROOT=../SeqLib
 VCFLIB_ROOT=../vcflib
 TABIX_ROOT=$(VCFLIB_ROOT)/tabixpp
 HTSLIB_ROOT=$(TABIX_ROOT)/htslib
 
 LIBS = -lz -lm -lpthread
-INCLUDE = -I../ttmath -I$(BAMTOOLS_ROOT)/src/ -I$(VCFLIB_ROOT)/src/ -I$(TABIX_ROOT)/ -I$(VCFLIB_ROOT)/smithwaterman/ -I$(VCFLIB_ROOT)/multichoose/ -I$(VCFLIB_ROOT)/filevercmp/ -I$(HTSLIB_ROOT) -I$(SEQLIB_ROOT) -I$(SEQLIB_ROOT)/htslib
+INCLUDE = -I../ttmath -I$(BAMTOOLS_ROOT)/src/ -I$(VCFLIB_ROOT)/src/ -I$(TABIX_ROOT)/ -I$(VCFLIB_ROOT)/smithwaterman/ -I$(VCFLIB_ROOT)/multichoose/ -I$(VCFLIB_ROOT)/filevercmp/ -I$(HTSLIB_ROOT) -DHAVE_BAMTOOLS=1
 
 all: autoversion ../bin/freebayes ../bin/bamleftalign
 
@@ -42,9 +41,6 @@ $(BAMTOOLS_ROOT)/lib/libbamtools.a:
 	cd $(BAMTOOLS_ROOT) && mkdir -p build && cd build && cmake .. && $(MAKE)
 $(HTSLIB_ROOT)/libhts.a:
 	cd $(HTSLIB_ROOT) && make
-
-$(SEQLIB_ROOT)/src/libseqlib.a:
-	cd $(SEQLIB_ROOT) && ./configure && make 
 
 OBJECTS=BedReader.o \
 		CNV.o \
@@ -79,10 +75,7 @@ OBJECTS=BedReader.o \
 		../vcflib/smithwaterman/IndelAllele.o \
 		Variant.o \
 		$(BAMTOOLS_ROOT)/lib/libbamtools.a \
-			$(SEQLIB_ROOT)/src/libseqlib.a	\
-			$(SEQLIB_ROOT)/bwa/libbwa.a	\
-			$(SEQLIB_ROOT)/fermi-lite/libfml.a	\
-			$(SEQLIB_ROOT)/htslib/libhts.a
+		$(TABIX_ROOT)/htslib/libhts.a
 
 HEADERS=multichoose.h version_git.h
 
@@ -97,10 +90,10 @@ alleles ../bin/alleles: alleles.o $(OBJECTS) $(HEADERS)
 dummy ../bin/dummy: dummy.o $(OBJECTS) $(HEADERS)
 	$(CXX) $(CFLAGS) $(INCLUDE) dummy.o $(OBJECTS) -o ../bin/dummy $(LIBS)
 
-bamleftalign ../bin/bamleftalign: $(BAMTOOLS_ROOT)/lib/libbamtools.a $(SEQLIB_ROOT)/src/libseqlib.a $(SEQLIB_ROOT)/htslib/libhts.a bamleftalign.o Fasta.o LeftAlign.o IndelAllele.o split.o
-	$(CXX) $(CFLAGS) $(INCLUDE) bamleftalign.o Fasta.o Utility.o LeftAlign.o IndelAllele.o split.o $(BAMTOOLS_ROOT)/lib/libbamtools.a $(SEQLIB_ROOT)/src/libseqlib.a $(SEQLIB_ROOT)/htslib/libhts.a -o ../bin/bamleftalign $(LIBS)
+bamleftalign ../bin/bamleftalign: $(BAMTOOLS_ROOT)/lib/libbamtools.a bamleftalign.o Fasta.o LeftAlign.o IndelAllele.o split.o
+	$(CXX) $(CFLAGS) $(INCLUDE) bamleftalign.o Fasta.o Utility.o LeftAlign.o IndelAllele.o split.o $(BAMTOOLS_ROOT)/lib/libbamtools.a -o ../bin/bamleftalign $(LIBS)
 
-bamfiltertech ../bin/bamfiltertech: $(BAMTOOLS_ROOT)/lib/libbamtools.a $(SEQLIB_ROOT)/src/libseqlib.a $(SEQLIB_ROOT)/htslib/libhts.a bamfiltertech.o $(OBJECTS) $(HEADERS)
+bamfiltertech ../bin/bamfiltertech: $(BAMTOOLS_ROOT)/lib/libbamtools.a bamfiltertech.o $(OBJECTS) $(HEADERS)
 	$(CXX) $(CFLAGS) $(INCLUDE) bamfiltertech.o $(OBJECTS) -o ../bin/bamfiltertech $(LIBS)
 
 

--- a/src/Makefile.bamtools
+++ b/src/Makefile.bamtools
@@ -8,24 +8,18 @@
 CXX=g++
 C=gcc
 
-export CXXFLAGS
-export C
-export CC
-export CXX
-export LDFLAGS
-export LIBFLAGS
-
 # Compiler flags
 CFLAGS=-O3 -D_FILE_OFFSET_BITS=64 -g
 #CFLAGS=-O3 -static -D VERBOSE_DEBUG  # enables verbose debugging via --debug2
 
+BAMTOOLS_ROOT=../bamtools
 SEQLIB_ROOT=../SeqLib
 VCFLIB_ROOT=../vcflib
 TABIX_ROOT=$(VCFLIB_ROOT)/tabixpp
 HTSLIB_ROOT=$(TABIX_ROOT)/htslib
 
 LIBS = -lz -lm -lpthread
-INCLUDE = -I../ttmath -I$(VCFLIB_ROOT)/src/ -I$(TABIX_ROOT)/ -I$(VCFLIB_ROOT)/smithwaterman/ -I$(VCFLIB_ROOT)/multichoose/ -I$(VCFLIB_ROOT)/filevercmp/ -I$(HTSLIB_ROOT) -I$(SEQLIB_ROOT) -I$(SEQLIB_ROOT)/htslib
+INCLUDE = -I../ttmath -I$(BAMTOOLS_ROOT)/src/ -I$(VCFLIB_ROOT)/src/ -I$(TABIX_ROOT)/ -I$(VCFLIB_ROOT)/smithwaterman/ -I$(VCFLIB_ROOT)/multichoose/ -I$(VCFLIB_ROOT)/filevercmp/ -I$(HTSLIB_ROOT) -I$(SEQLIB_ROOT) -I$(SEQLIB_ROOT)/htslib
 
 all: autoversion ../bin/freebayes ../bin/bamleftalign
 
@@ -43,6 +37,9 @@ gprof:
 
 .PHONY: all static debug profiling gprof
 
+# builds bamtools static lib, and copies into root
+$(BAMTOOLS_ROOT)/lib/libbamtools.a:
+	cd $(BAMTOOLS_ROOT) && mkdir -p build && cd build && cmake .. && $(MAKE)
 $(HTSLIB_ROOT)/libhts.a:
 	cd $(HTSLIB_ROOT) && make
 
@@ -81,6 +78,7 @@ OBJECTS=BedReader.o \
 		../vcflib/smithwaterman/Repeats.o \
 		../vcflib/smithwaterman/IndelAllele.o \
 		Variant.o \
+		$(BAMTOOLS_ROOT)/lib/libbamtools.a \
 			$(SEQLIB_ROOT)/src/libseqlib.a	\
 			$(SEQLIB_ROOT)/bwa/libbwa.a	\
 			$(SEQLIB_ROOT)/fermi-lite/libfml.a	\
@@ -99,10 +97,10 @@ alleles ../bin/alleles: alleles.o $(OBJECTS) $(HEADERS)
 dummy ../bin/dummy: dummy.o $(OBJECTS) $(HEADERS)
 	$(CXX) $(CFLAGS) $(INCLUDE) dummy.o $(OBJECTS) -o ../bin/dummy $(LIBS)
 
-bamleftalign ../bin/bamleftalign: $(SEQLIB_ROOT)/src/libseqlib.a $(SEQLIB_ROOT)/htslib/libhts.a bamleftalign.o Fasta.o LeftAlign.o IndelAllele.o split.o
-	$(CXX) $(CFLAGS) $(INCLUDE) bamleftalign.o Fasta.o Utility.o LeftAlign.o IndelAllele.o split.o $(SEQLIB_ROOT)/src/libseqlib.a $(SEQLIB_ROOT)/htslib/libhts.a -o ../bin/bamleftalign $(LIBS)
+bamleftalign ../bin/bamleftalign: $(BAMTOOLS_ROOT)/lib/libbamtools.a $(SEQLIB_ROOT)/src/libseqlib.a $(SEQLIB_ROOT)/htslib/libhts.a bamleftalign.o Fasta.o LeftAlign.o IndelAllele.o split.o
+	$(CXX) $(CFLAGS) $(INCLUDE) bamleftalign.o Fasta.o Utility.o LeftAlign.o IndelAllele.o split.o $(BAMTOOLS_ROOT)/lib/libbamtools.a $(SEQLIB_ROOT)/src/libseqlib.a $(SEQLIB_ROOT)/htslib/libhts.a -o ../bin/bamleftalign $(LIBS)
 
-bamfiltertech ../bin/bamfiltertech: $(SEQLIB_ROOT)/src/libseqlib.a $(SEQLIB_ROOT)/htslib/libhts.a bamfiltertech.o $(OBJECTS) $(HEADERS)
+bamfiltertech ../bin/bamfiltertech: $(BAMTOOLS_ROOT)/lib/libbamtools.a $(SEQLIB_ROOT)/src/libseqlib.a $(SEQLIB_ROOT)/htslib/libhts.a bamfiltertech.o $(OBJECTS) $(HEADERS)
 	$(CXX) $(CFLAGS) $(INCLUDE) bamfiltertech.o $(OBJECTS) -o ../bin/bamfiltertech $(LIBS)
 
 
@@ -117,7 +115,7 @@ alleles.o: alleles.cpp AlleleParser.o Allele.o
 dummy.o: dummy.cpp AlleleParser.o Allele.o
 	$(CXX) $(CFLAGS) $(INCLUDE) -c dummy.cpp
 
-freebayes.o: freebayes.cpp TryCatch.h $(HTSLIB_ROOT)/libhts.a 
+freebayes.o: freebayes.cpp TryCatch.h $(HTSLIB_ROOT)/libhts.a $(BAMTOOLS_ROOT)/lib/libbamtools.a
 	$(CXX) $(CFLAGS) $(INCLUDE) -c freebayes.cpp
 
 fastlz.o: fastlz.c fastlz.h
@@ -138,7 +136,7 @@ Genotype.o: Genotype.cpp Genotype.h Allele.h multipermute.h
 Ewens.o: Ewens.cpp Ewens.h
 	$(CXX) $(CFLAGS) $(INCLUDE) -c Ewens.cpp
 
-AlleleParser.o: AlleleParser.cpp AlleleParser.h multichoose.h Parameters.h $(HTSLIB_ROOT)/libhts.a
+AlleleParser.o: AlleleParser.cpp AlleleParser.h multichoose.h Parameters.h $(BAMTOOLS_ROOT)/lib/libbamtools.a $(HTSLIB_ROOT)/libhts.a
 	$(CXX) $(CFLAGS) $(INCLUDE) -c AlleleParser.cpp
 
 Utility.o: Utility.cpp Utility.h Sum.h Product.h
@@ -186,7 +184,7 @@ bamleftalign.o: bamleftalign.cpp LeftAlign.cpp
 bamfiltertech.o: bamfiltertech.cpp
 	$(CXX) $(CFLAGS) $(INCLUDE) -c bamfiltertech.cpp
 
-LeftAlign.o: LeftAlign.h LeftAlign.cpp $(HTSLIB_ROOT)/libhts.a
+LeftAlign.o: LeftAlign.h LeftAlign.cpp $(BAMTOOLS_ROOT)/lib/libbamtools.a $(HTSLIB_ROOT)/libhts.a
 	$(CXX) $(CFLAGS) $(INCLUDE) -c LeftAlign.cpp
 
 IndelAllele.o: IndelAllele.cpp IndelAllele.h
@@ -277,6 +275,6 @@ autoversion:
 
 clean:
 	rm -rf *.o *.cgh *~ freebayes alleles ../bin/freebayes ../bin/alleles ../vcflib/*.o ../vcflib/tabixpp/*.{o,a}
+	cd $(BAMTOOLS_ROOT)/build && make clean
 	cd ../vcflib/smithwaterman && make clean
-	cd ../SeqLib && make clean
 

--- a/src/Sample.cpp
+++ b/src/Sample.cpp
@@ -142,7 +142,7 @@ double Samples::observationCountInclPartials(void) {
 }
 
 int Samples::qualSum(Allele& allele) {
-    qualSum(allele.currentBase);
+    return qualSum(allele.currentBase);
 }
 
 int Samples::qualSum(const string& base) {
@@ -154,7 +154,7 @@ int Samples::qualSum(const string& base) {
 }
 
 double Samples::partialQualSum(Allele& allele) {
-    partialQualSum(allele.currentBase);
+    return partialQualSum(allele.currentBase);
 }
 
 double Samples::partialQualSum(const string& base) {

--- a/src/bamleftalign.cpp
+++ b/src/bamleftalign.cpp
@@ -152,6 +152,7 @@ int main(int argc, char** argv) {
         cerr << "could not open stdout for writing" << endl;
         exit(1);
     }
+    writer.WriteHeader();
 #endif
 
     // store the names of all the reference sequences in the BAM file

--- a/src/freebayes.cpp
+++ b/src/freebayes.cpp
@@ -19,7 +19,9 @@
 #include <stdlib.h>
 
 // private libraries
+#ifdef HAVE_BAMTOOLS
 #include "api/BamReader.h"
+#endif
 #include "Fasta.h"
 #include "TryCatch.h"
 #include "Parameters.h"


### PR DESCRIPTION
This PR address issue [334](https://github.com/ekg/freebayes/issues/334) which noticed an issue with compiler flags not being passed to the SeqLib build. In addition:
-- separates CXXFLAGS from CFLAGS, and separates out the BAMTools build into ```src/Makefile.bamtools```
-- addresses a few minor compiler warnings
-- update to lighter SeqLib, which removes some heavy files from the repos