### PR TITLE
Note unstated dependency on zlib

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,8 @@ Luckily, if you have access to https:// on port 443, then you can use this
 
 ## Compilation
 
-FreeBayes requires g++ and the standard C and C++ development libraries.
+FreeBayes requires g++ and the standard C and C++ development libraries, as
+well as zlib.
 Additionally, cmake is required for building the BamTools API.
 
     make


### PR DESCRIPTION
Freebayes depends on zlib, although this was not noted in the README, which is understandable because zlib is so common that a dependency on it is so easy to ignore.