### PR TITLE
Improve handling of complex alleles

### DIFF
--- a/src/Allele.cpp
+++ b/src/Allele.cpp
@@ -1415,9 +1415,9 @@ int referenceLengthFromCigar(string& cigar) {
         case 'M':
         case 'X':
         case 'D':
-        case 'N':
             r += c->first;
             break;
+        case 'N':
         case 'I':
         default:
             break;
@@ -1434,9 +1434,9 @@ int Allele::referenceLengthFromCigar(void) {
         case 'M':
         case 'X':
         case 'D':
-        case 'N':
             r += c->first;
             break;
+        case 'N':
         case 'I':
         default:
             break;
@@ -1448,30 +1448,21 @@ int Allele::referenceLengthFromCigar(void) {
 
 // combines the two alleles into a complex variant, updates important data
 void Allele::mergeAllele(const Allele& newAllele, AlleleType newType) {
-    //cout << stringForAllele(*this) << endl << stringForAllele(newAllele) << endl;
+    //cerr << stringForAllele(*this) << endl << stringForAllele(newAllele) << endl;
     type = newType;
     alternateSequence += newAllele.alternateSequence;
     length += newAllele.length; // hmmm
     basesRight = newAllele.basesRight;
     baseQualities.insert(baseQualities.end(), newAllele.baseQualities.begin(), newAllele.baseQualities.end());
     currentBase = base();
-    // XXX note that we don't add Q values for intermingled gaps in combined alleles
-    if (newAllele.type != ALLELE_REFERENCE) {
-        quality = min(newAllele.quality, quality);
-        lnquality = max(newAllele.lnquality, lnquality);
-        //quality = minQuality(baseQualities);
-        //lnquality = log(quality);
-    } else {
-        quality = averageQuality(baseQualities);
-        lnquality = log(quality);
-        basesRight += newAllele.referenceLength;
-    }
+    quality = averageQuality(baseQualities);
+    lnquality = phred2ln(quality);
+    basesRight += newAllele.referenceLength;
     if (newAllele.type != ALLELE_REFERENCE) {
         repeatRightBoundary = newAllele.repeatRightBoundary;
     }
     cigar = mergeCigar(cigar, newAllele.cigar);
     referenceLength = referenceLengthFromCigar();
-    //cout << stringForAllele(*this) << endl << endl;
 }
 
 void Allele::squash(void) {

--- a/src/AlleleParser.h
+++ b/src/AlleleParser.h
@@ -77,6 +77,7 @@ public:
     void addAllele(Allele allele, bool mergeComplex = true,
                    int maxComplexGap = 0, bool boundIndels = false);
     bool fitHaplotype(int pos, int haplotypeLength, Allele*& aptr, bool allowPartials = false);
+    void clumpAlleles(bool mergeComplex = true, int maxComplexGap = 0, bool boundIndels = false);
 
 };
 

--- a/src/Parameters.cpp
+++ b/src/Parameters.cpp
@@ -202,7 +202,7 @@ void Parameters::usage(char** argv) {
         << "   -E --max-complex-gap N" << endl
         << "      --haplotype-length N" << endl
         << "                   Allow haplotype calls with contiguous embedded matches of up" << endl
-        << "                   to this length.  (default: 3)" << endl
+        << "                   to this length. Set N=-1 to disable clumping. (default: 3)" << endl
         << "   --min-repeat-size N" << endl
         << "                   When assembling observations across repeats, require the total repeat" << endl
         << "                   length at least this many bp.  (default: 5)" << endl

--- a/src/freebayes.cpp
+++ b/src/freebayes.cpp
@@ -305,7 +305,8 @@ int main (int argc, char *argv[]) {
         string referenceBase = parser->currentReferenceHaplotype();
 
 
-        /* for debugging
+        // for debugging
+        /*
         for (Samples::iterator s = samples.begin(); s != samples.end(); ++s) {
             string sampleName = s->first;
             Sample& sample = s->second;

--- a/test/t/00_region_and_target_handling.t
+++ b/test/t/00_region_and_target_handling.t
@@ -36,7 +36,7 @@ ALT
 samtools view -S -b - >$bam <<SAM
 @HD	VN:1.5	SO:coordinate
 @SQ	SN:ref	LN:11
-alt	0	ref	1	30	1X1=2X1=1X1=1X2=1X	*	0	0	GTTAGGTTAAC	*
+alt	0	ref	1	30	1X1=2X1=1X1=1X2=1X	*	0	0	GTTAGGTTAAC	IIIIIIIIIII
 SAM
 samtools index $bam
 
@@ -70,7 +70,7 @@ PS4='\n+ '
 function run_freebayes() {
     ($root/bin/freebayes "$@" \
         --haplotype-length 0 --min-alternate-count 1 \
-        --min-alternate-fraction 0 --pooled-continuous --report-monomorphic \
+        --min-alternate-fraction 0 --pooled-continuous \
         --ploidy 1 \
         -f $ref $bam \
         | grep -vE "^#" | cut -f1-5)

--- a/test/t/01_call_variants.t
+++ b/test/t/01_call_variants.t
@@ -17,7 +17,8 @@ by_region=$((for region in \
     q:1811-1825 \
     q:1911-1922 \
     q:2344-2355 \
-    q:3257-3268 \
+    q:2630-2635 \
+    q:3250-3268 \
     q:4443-4454 \
     q:5003-5014 \
     q:5074-5085 \
@@ -45,7 +46,8 @@ q	1002	1013
 q	1811	1825
 q	1911	1922
 q	2344	2355
-q	3257	3268
+q	2630	2635
+q	3250	3268
 q	4443	4454
 q	5003	5014
 q	5074	5085
@@ -103,7 +105,7 @@ is $(freebayes -f tiny/q.fa tiny/NA12878.chr22.tiny.bam | grep -v "^#" | wc -l) 
 #is $(freebayes -f 'tiny/q with spaces.fa' tiny/NA12878.chr22.tiny.bam | grep -v "^#" | wc -l) $(freebayes-parallel 'tiny/q with spaces.regions' 2 -f 'tiny/q with spaces.fa' tiny/NA12878.chr22.tiny.bam | grep -v "^#" | wc -l) "freebayes handles spaces in file names"
 
 
-is $(freebayes -f splice/1:883884-887618.fa splice/1:883884-887618.bam | grep ^1 | wc -l) 1 "freebayes can handle spliced reads"
+is $(freebayes -f splice/1:883884-887618.fa splice/1:883884-887618.bam -F 0.05 -C 1 | grep ^1 | wc -l) 3 "freebayes can handle spliced reads"
 
 is $(freebayes -f tiny/q.fa tiny/NA12878.chr22.tiny.bam --gvcf | grep '<\*>' | wc -l) 20 "freebayes produces the expected number of lines of gVCF output"
 

--- a/test/t/02_multi_bam.t
+++ b/test/t/02_multi_bam.t
@@ -9,7 +9,7 @@ plan tests 7
 
 ref=$(basename $0).ref
 
-#trap 'rm -f ${ref}* $(basename $0)*.bam*' EXIT
+trap 'rm -f ${ref}* $(basename $0)*.bam*' EXIT
 
 cat >${ref} <<REF
 >ref

--- a/test/t/02_multi_bam.t
+++ b/test/t/02_multi_bam.t
@@ -9,7 +9,7 @@ plan tests 7
 
 ref=$(basename $0).ref
 
-trap 'rm -f ${ref}* $(basename $0)*.bam*' EXIT
+#trap 'rm -f ${ref}* $(basename $0)*.bam*' EXIT
 
 cat >${ref} <<REF
 >ref
@@ -20,7 +20,7 @@ samtools faidx ${ref}
 function run_freebayes() {
     freebayes "$@" \
               --haplotype-length 0 --min-alternate-count 1 \
-              --min-alternate-fraction 0 --pooled-continuous --report-monomorphic \
+              --min-alternate-fraction 0 --pooled-continuous  \
               --ploidy 1 \
               -f $ref $bam \
               2>&1 \
@@ -39,7 +39,7 @@ function make_bam() {
 @HD	VN:1.5	SO:coordinate
 @SQ	SN:ref	LN:9
 @RG	ID:${id}	SM:${sm}	PL:${pl}
-alt	0	ref	1	30	1=1X1=2X1=1X1=1X	*	0	0	A${first_snp}TTAGGTT	*	RG:Z:${id}
+alt	0	ref	1	30	1=1X1=2X1=1X1=1X	*	0	0	A${first_snp}TTAGGTT	AAAAAAAAA	RG:Z:${id}
 SAM
     samtools index ${bam}
     echo ${bam}

--- a/test/t/03_reference_bases.t
+++ b/test/t/03_reference_bases.t
@@ -24,13 +24,13 @@ REF
 samtools view -S -b - >${bam} <<SAM
 @HD	VN:1.5	SO:coordinate
 @SQ	SN:ref	LN:31
-alt	0	ref	1	30	13=1X1=12X1=1X1=1X	*	0	0	CCCCCCCCCCCCAGTTAAAAAAAAAAAGGTT	*
+alt	0	ref	1	30	13=1X1=12X1=1X1=1X	*	0	0	CCCCCCCCCCCCAGTTAAAAAAAAAAAGGTT	AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
 SAM
 samtools index ${bam}
 
 function run_freebayes() {
     freebayes --haplotype-length 0 --min-alternate-count 1 \
-              --min-alternate-fraction 0 --pooled-continuous --report-monomorphic \
+              --min-alternate-fraction 0 --pooled-continuous \
               --ploidy 1 \
               -f $ref $bam \
               2>&1 \


### PR DESCRIPTION
The complexity of the allele parsing algorithm that converted a read into a series of alleles made it easy for us to introduce a number of bugs, the ultimate result of which was an elimination of certain kinds of complex alleles. These commits rewrite the allele parsing logic to be simpler and easier to maintain, and resolve the underlying problem. They also resolve a number of other minor issues, such as a problem with reported depth in some contexts.