### PR TITLE
resolve #406

### DIFF
--- a/src/AlleleParser.h
+++ b/src/AlleleParser.h
@@ -250,7 +250,7 @@ public:
     void removeNonOverlappingAlleles(vector<Allele*>& alleles,
                                      int haplotypeLength = 1,
                                      bool getAllAllelesInHaplotype = false);
-    void removePreviousAlleles(vector<Allele*>& alleles);
+    void removePreviousAlleles(vector<Allele*>& alleles, long int position);
     void removeFilteredAlleles(vector<Allele*>& alleles);
     void removeDuplicateAlleles(Samples& samples, map<string, vector<Allele*> >& alleleGroups,
                                 int allowedAlleleTypes, int haplotypeLength, Allele& refallele);

--- a/src/Makefile
+++ b/src/Makefile
@@ -17,7 +17,7 @@ export LIBFLAGS
 
 # Compiler flags
 
-CFLAGS=-O3 -D_FILE_OFFSET_BITS=64 -g
+CFLAGS=-O3 -D_FILE_OFFSET_BITS=64 -g -ggdb
 #CFLAGS=-O3 -static -D VERBOSE_DEBUG  # enables verbose debugging via --debug2
 
 SEQLIB_ROOT=../SeqLib


### PR DESCRIPTION
The allele parser could end up in a state where we deleted alignment before
their parsed alleles were removed from the list of registered alleles. Touching
these could in turn cause segfaults and other undefined behavior. This commit
ensures we clean up the pointers to the removed alleles correctly.