### PR TITLE
Give warning when there is a likely mismatch between alignment and reference sequence

### DIFF
--- a/src/AlleleParser.cpp
+++ b/src/AlleleParser.cpp
@@ -1454,13 +1454,11 @@ RegisteredAlignment& AlleleParser::registerAlignment(BAMALIGN& alignment, Regist
                 try {
                     sb = currentSequence.at(csp);
                 } catch (std::out_of_range outOfRange) {
-		  cerr << "Exception: Unable to read reference sequence base past end of current cached sequence." << endl
-                         << currentSequenceName << ":" << (long unsigned int) currentPosition + 1 << endl
-		       << alignment.POSITION << "-" << alignment.ENDPOSITION << endl
-		    //<< "alignment: " << alignment.AlignedBases << endl
-		       << "currentSequence: " << currentSequence << endl
-		       << "currentSequence matching: " << currentSequence.substr(csp, alignment.ALIGNEDBASES) << endl;
-		  //abort();
+                    cerr << "Exception: Alignment reports a match past the end of the current reference sequence." << endl
+                         << "This suggests alignment corruption or a mismatch between this reference and the alignments." << endl
+                         << "Are you sure that you are calling against the same reference you aligned to?" << endl
+                         << "Sequence: " << currentSequenceName << ":" << (long unsigned int) currentPosition + 1 << endl
+                         << "Alignment: " << alignment.QNAME << " @ " << alignment.POSITION << "-" << alignment.ENDPOSITION << endl;
                     break;
                 }
 


### PR DESCRIPTION
It could also mean that alignments are corrupted.

In any case this should be clearer than the error was before. It referred to "cached reference sequence", which is a strange concept that doesn't really exist in freebayes anymore.