### PR TITLE
Support for compilation with Cygwin 64

### DIFF
--- a/src/LargeFileSupport.h
+++ b/src/LargeFileSupport.h
@@ -4,6 +4,10 @@
 #define ftell64(a)     _ftelli64(a)
 #define fseek64(a,b,c) _fseeki64(a,b,c)
 typedef __int64 off_type;
+#elif defined(__CYGWIN__)
+#define ftell64(a)     ftell(a)
+#define fseek64(a,b,c) fseek(a,b,c)
+typedef __int64_t off_type;
 #elif defined(__APPLE__)
 #define ftell64(a)     ftello(a)
 #define fseek64(a,b,c) fseeko(a,b,c)

--- a/src/SegfaultHandler.cpp
+++ b/src/SegfaultHandler.cpp
@@ -4,6 +4,7 @@
 // many thanks to tgamblin
 
 void segfaultHandler(int sig) {
+#ifndef __CYGWIN__
     void *array[10];
     size_t size;
 
@@ -13,5 +14,6 @@ void segfaultHandler(int sig) {
     // print out all the frames to stderr
     fprintf(stderr, "Error: signal %d:\n", sig);
     backtrace_symbols_fd(array, size, 2);
+#endif
     exit(1);
 }

--- a/src/SegfaultHandler.h
+++ b/src/SegfaultHandler.h
@@ -2,7 +2,9 @@
 #define SEGFAULTHANDLER_H
 
 #include <stdio.h>
+#ifndef __CYGWIN__
 #include <execinfo.h>
+#endif
 #include <signal.h>
 #include <stdlib.h>
 


### PR DESCRIPTION
Changes to allow FreeBayes to be built with 64-bit Cygwin. Verified with GCC 6.4.0 on Windows 10.