### PR TITLE
allow calling on N-matching reference bases

### DIFF
--- a/src/freebayes.cpp
+++ b/src/freebayes.cpp
@@ -134,10 +134,10 @@ int main (int argc, char *argv[]) {
             nonCalls.clear();
         }
 
-        // don't process non-ATGC's in the reference
+        // don't process non-ATGCN's in the reference
         string cb = parser->currentReferenceBaseString();
-        if (cb != "A" && cb != "T" && cb != "C" && cb != "G") {
-            DEBUG2("current reference base is N");
+        if (cb != "A" && cb != "T" && cb != "C" && cb != "G" && cb != "N") {
+            DEBUG2("current reference base is not in { A T G C N }");
             continue;
         }
 


### PR DESCRIPTION
This is as advertised. There are a number of applications (such as assembly polishing) where this matters. I don't think there are any clear drawbacks provided users consider the reference base in downstream analysis.