### PR TITLE
clarify the effect of allele exclusion filters and document best practices

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,26 @@ For a description of available command-line options and their defaults, run:
 
     freebayes --help
 
+## Getting the best results
+
+freebayes provides many options to configure its operation.
+These may be important in certain use cases, but they are not meant for standard use.
+It is strongly recommended that you run freebayes with parameters that are as close to default as possible unless you can validate that the chosen parameters improve performance.
+To achieve the desired tradeoff between sensitivity and specificity, the best approach is to filter the output using the `QUAL` field, which encodes the posterior estimate of the probability of variation.
+
+Filtering the input with the provided options demonstrably hurts performance where truth sets can be used to evaluate results.
+By removing information from the input, you can confuse the Bayesian model by making it appear that certain alleles frequently indicative of context specific error (such as indels in homopolymers) don't exist.
+
+Many users apply these filters to force freebayes to not make haplotype calls.
+This is almost always a mistake, as the haplotype calling process greatly improves the method's signal to noise ratio and normalizes differential alignment in complex regions.
+
+If you wish to obtain a VCF that does not contain haplotype calls or complex alleles, first call with default parameters and then decompose the output with tools in vcflib, vt, vcf-tools, bcftools, GATK, and Picard.
+Here we use a tool in vcflib that normalizes the haplotype calls into pointwise SNPs and indels:
+
+    freebayes ... | vcfallelicprimitives -kg >calls.vcf
+
+Note that this is not done by default as it makes it difficult to determine which variant calls freebayes completed.
+The raw output faithfully describes exactly the calls that were made.
 
 ## Examples
 

--- a/src/Parameters.cpp
+++ b/src/Parameters.cpp
@@ -194,10 +194,6 @@ void Parameters::usage(char** argv) {
         << endl
         << "allele scope:" << endl
         << endl
-        << "   -I --no-snps    Ignore SNP alleles." << endl
-        << "   -i --no-indels  Ignore insertion and deletion alleles." << endl
-        << "   -X --no-mnps    Ignore multi-nuceotide polymorphisms, MNPs." << endl
-        << "   -u --no-complex Ignore complex events (composites of other classes)." << endl
         << "   -n --use-best-n-alleles N" << endl
         << "                   Evaluate only the best N SNP alleles, ranked by sum of" << endl
         << "                   supporting quality scores.  (Set to 0 to use all; default: all)" << endl
@@ -215,6 +211,23 @@ void Parameters::usage(char** argv) {
         << "                   Exclude observations which do not fully span the dynamically-determined" << endl
         << "                   detection window.  (default, use all observations, dividing partial" << endl
         << "                   support across matching haplotypes when generating haplotypes.)" << endl
+        << endl
+        << "  These flags are meant for testing." << endl
+        << "  They are not meant for filtering the output." << endl
+        << "  They actually filter the input to the algorithm by throwing away alignments." << endl
+        << "  This hurts performance by hiding information from the Bayesian model." << endl
+        << "  Do not use them unless you can validate that they improve results!" << endl
+        << endl
+        << "   -I --throw-away-snp-obs     Remove SNP observations from input." << endl
+        << "   -i --throw-away-indels-obs  Remove indel observations from input." << endl
+        << "   -X --throw-away-mnp-obs     Remove MNP observations from input." << endl
+        << "   -u --throw-away-complex-obs Remove complex allele observations from input." << endl
+        << endl
+        << "  If you need to break apart haplotype calls to obtain one class of alleles," << endl
+        << "  run the call with default parameters, then normalize and subset the VCF:" << endl
+        << "    freebayes ... | vcfallelicprimitives -kg >calls.vcf" << endl
+        << "  For example, this would retain only biallelic SNPs." << endl
+        << "    <calls.vcf vcfsnps | vcfbiallelic >biallelic_snp_calls.vcf" << endl
         << endl
         << "indel realignment:" << endl
         << endl
@@ -507,15 +520,15 @@ Parameters::Parameters(int argc, char** argv) {
             {"read-max-mismatch-fraction", required_argument, 0, 'z'},
             {"read-snp-limit", required_argument, 0, '$'},
             {"read-indel-limit", required_argument, 0, 'e'},
-            {"no-indels", no_argument, 0, 'i'},
+            {"throw-away-indel-obs", no_argument, 0, 'i'},
             {"dont-left-align-indels", no_argument, 0, 'O'},
-            {"no-mnps", no_argument, 0, 'X'},
-            {"no-complex", no_argument, 0, 'u'},
+            {"throw-away-mnps-obs", no_argument, 0, 'X'},
+            {"throw-away-complex-obs", no_argument, 0, 'u'},
             {"max-complex-gap", required_argument, 0, 'E'},
             {"haplotype-length", required_argument, 0, 'E'},
             {"min-repeat-size", required_argument, 0, 'E'},
             {"min-repeat-entropy", required_argument, 0, 'E'},
-            {"no-snps", no_argument, 0, 'I'},
+            {"throw-away-snp-obs", no_argument, 0, 'I'},
             {"indel-exclusion-window", required_argument, 0, 'x'},
             {"theta", required_argument, 0, 'T'},
             {"pvar", required_argument, 0, 'P'},


### PR DESCRIPTION
A lot of my support effort goes into correcting aggressive use of input filters. Here I am trying to improve the documentation and command line interface to explain the risks of this approach.

For example, I rename the popular allele observation exclusion filters `--no-snps`, `--no-indels`, `--no-mnps` and `--no-complex` to indicate what they are actually doing:

```
   -I --throw-away-snp-obs     Remove SNP observations from input.                
   -i --throw-away-indels-obs  Remove indel observations from input.
   -X --throw-away-mnp-obs     Remove MNP observations from input.                
   -u --throw-away-complex-obs Remove complex allele observations from input.      
```

Apparently most users believed these were filtering the _output_. They do not. They throw away read observations that can help you get the right call.

I know that users appreciate the openness of freebayes, that it allows you to precisely configure the input to the algorithm. I am sure this is important in many use cases, and as long as the results are validated I think is perfectly fine. However, it is not good to use these input filters to effect filters that should be applied after the calling is completed, particularly when one is operating in a context where there is no truth set. I want to do what I can to encourage caution.

One thing that occurs to me is that a really important change when working in non-model organisms is to adjust the expected pairwise heterozygosity, `--theta` to match that of the organism in question. This really makes a difference as it's the only free model parameter. It might be good for me to add this note to the README.

I'd love to know what users think about this. Have I misinterpreted the use of `--no-indels` and friends?