### PR TITLE
Skip high coverage regions by throwing away reads when they overlap a position with coverage above a given threshold

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+#CFLAGS=-O3 -D_FILE_OFFSET_BITS=64 -g
+#CXXFLAGS=-O3 -D_FILE_OFFSET_BITS=64 -g
+
 all: vcflib/Makefile log
 	cd src && $(MAKE)
 

--- a/README.md
+++ b/README.md
@@ -165,6 +165,10 @@ Require at least 5 supporting observations to consider a variant:
 
     freebayes -f ref.fa -C 5 aln.bam >var.vcf
 
+Skip over regions of high depth by discarding alignments overlapping positions where total read depth is greater than 200:
+
+    freebayes -f ref.fa -g 200 aln.bam >var.vcf
+
 Use a different ploidy:
 
     freebayes -f ref.fa -p 4 aln.bam >var.vcf

--- a/src/AlleleParser.cpp
+++ b/src/AlleleParser.cpp
@@ -2022,9 +2022,6 @@ void AlleleParser::updateAlignmentQueue(long int position,
                 if (parameters.baseQualityCap != 0) {
                     capBaseQuality(currentAlignment, parameters.baseQualityCap);
                 }
-                // decomposes alignment into a set of alleles
-                // here we get the deque of alignments ending at this alignment's end position
-                deque<RegisteredAlignment>& rq = registeredAlignments[currentAlignment.ENDPOSITION];
                 // do we exceed coverage anywhere?
                 // do we touch anything where we had exceeded coverage?
                 // if so skip this read, and mark and remove processed alignments and registered alleles overlapping the coverage capped position
@@ -2047,7 +2044,9 @@ void AlleleParser::updateAlignmentQueue(long int position,
                         }
                     }
                 }
-                
+                // decomposes alignment into a set of alleles
+                // here we get the deque of alignments ending at this alignment's end position
+                deque<RegisteredAlignment>& rq = registeredAlignments[currentAlignment.ENDPOSITION];
                 //cerr << "parameters capcoverage " << parameters.capCoverage << " " << rq.size() << endl;
                 if (considerAlignment) {
                     // and insert the registered alignment into that deque

--- a/src/AlleleParser.cpp
+++ b/src/AlleleParser.cpp
@@ -2029,19 +2029,21 @@ void AlleleParser::updateAlignmentQueue(long int position,
                 // do we touch anything where we had exceeded coverage?
                 // if so skip this read, and mark and remove processed alignments and registered alleles overlapping the coverage capped position
                 bool considerAlignment = true;
-                for (unsigned long int i =  currentAlignment.POSITION; i < currentAlignment.ENDPOSITION; ++i) {
-                    unsigned long int x = ++coverage[i];
-                    if (x > parameters.capCoverage) {
-                        considerAlignment = false;
-                        // we're exceeding coverage at this position for the first time, so clean up
-                        if (!coverageCappedPositions.count(i)) {
-                            // clean up reads overlapping this position
-                            removeCappedAlleles(registeredAlleles, i);
-                            removeCappedAlleles(newAlleles, i);
-                            // remove the alignments overlapping this position
-                            removeRegisteredAlignmentsOverlappingPosition(i);
-                            // record that the position is capped
-                            coverageCappedPositions.insert(i);
+                if (parameters.capCoverage > 0) {
+                    for (unsigned long int i =  currentAlignment.POSITION; i < currentAlignment.ENDPOSITION; ++i) {
+                        unsigned long int x = ++coverage[i];
+                        if (x > parameters.capCoverage) {
+                            considerAlignment = false;
+                            // we're exceeding coverage at this position for the first time, so clean up
+                            if (!coverageCappedPositions.count(i)) {
+                                // clean up reads overlapping this position
+                                removeCappedAlleles(registeredAlleles, i);
+                                removeCappedAlleles(newAlleles, i);
+                                // remove the alignments overlapping this position
+                                removeRegisteredAlignmentsOverlappingPosition(i);
+                                // record that the position is capped
+                                coverageCappedPositions.insert(i);
+                            }
                         }
                     }
                 }

--- a/src/AlleleParser.cpp
+++ b/src/AlleleParser.cpp
@@ -2029,20 +2029,20 @@ void AlleleParser::updateAlignmentQueue(long int position,
                 // do we touch anything where we had exceeded coverage?
                 // if so skip this read, and mark and remove processed alignments and registered alleles overlapping the coverage capped position
                 bool considerAlignment = true;
-                if (parameters.capCoverage > 0) {
+                if (parameters.skipCoverage > 0) {
                     for (unsigned long int i =  currentAlignment.POSITION; i < currentAlignment.ENDPOSITION; ++i) {
                         unsigned long int x = ++coverage[i];
-                        if (x > parameters.capCoverage) {
+                        if (x > parameters.skipCoverage) {
                             considerAlignment = false;
                             // we're exceeding coverage at this position for the first time, so clean up
-                            if (!coverageCappedPositions.count(i)) {
+                            if (!coverageSkippedPositions.count(i)) {
                                 // clean up reads overlapping this position
-                                removeCappedAlleles(registeredAlleles, i);
-                                removeCappedAlleles(newAlleles, i);
+                                removeCoverageSkippedAlleles(registeredAlleles, i);
+                                removeCoverageSkippedAlleles(newAlleles, i);
                                 // remove the alignments overlapping this position
                                 removeRegisteredAlignmentsOverlappingPosition(i);
                                 // record that the position is capped
-                                coverageCappedPositions.insert(i);
+                                coverageSkippedPositions.insert(i);
                             }
                         }
                     }
@@ -2568,7 +2568,7 @@ void AlleleParser::removePreviousAlleles(vector<Allele*>& alleles, long int posi
     alleles.erase(remove(alleles.begin(), alleles.end(), (Allele*)NULL), alleles.end());
 }
 
-void AlleleParser::removeCappedAlleles(vector<Allele*>& alleles, long int position) {
+void AlleleParser::removeCoverageSkippedAlleles(vector<Allele*>& alleles, long int position) {
     for (vector<Allele*>::iterator a = alleles.begin(); a != alleles.end(); ++a) {
         Allele* allele = *a;
         if (*a != NULL && allele->alignmentStart <= position && allele->alignmentEnd > position) {
@@ -2592,7 +2592,7 @@ bool AlleleParser::toNextTarget(void) {
     DEBUG("to next target");
 
     clearRegisteredAlignments();
-    coverageCappedPositions.clear();
+    coverageSkippedPositions.clear();
     cachedRepeatCounts.clear();
     coverage.clear();
 
@@ -2840,7 +2840,7 @@ bool AlleleParser::toNextPosition(void) {
                 || (registeredAlignments.empty() && currentRefID != currentAlignment.REFID)) {
                 DEBUG("at end of sequence");
                 clearRegisteredAlignments();
-                coverageCappedPositions.clear();
+                coverageSkippedPositions.clear();
                 cachedRepeatCounts.clear();
                 coverage.clear();
                 loadNextPositionWithAlignmentOrInputVariant(currentAlignment);
@@ -2937,8 +2937,8 @@ bool AlleleParser::toNextPosition(void) {
     }
 
     DEBUG2("erasing old coverage cap");
-    while (coverageCappedPositions.size() && *coverageCappedPositions.begin() < currentPosition) {
-        coverageCappedPositions.erase(coverageCappedPositions.begin());
+    while (coverageSkippedPositions.size() && *coverageSkippedPositions.begin() < currentPosition) {
+        coverageSkippedPositions.erase(coverageSkippedPositions.begin());
     }
 
     DEBUG2("erasing old coverage counts");

--- a/src/AlleleParser.h
+++ b/src/AlleleParser.h
@@ -195,7 +195,7 @@ public:
 
     vector<Allele*> registeredAlleles;
     map<long unsigned int, deque<RegisteredAlignment> > registeredAlignments;
-    set<long unsigned int> coverageCappedPositions;
+    set<long unsigned int> coverageSkippedPositions;
     map<long unsigned int, long unsigned int> coverage;
     map<int, map<long int, vector<Allele> > > inputVariantAlleles; // all variants present in the input VCF, as 'genotype' alleles
     pair<int, long int> nextInputVariantPosition(void);
@@ -253,7 +253,7 @@ public:
                                      int haplotypeLength = 1,
                                      bool getAllAllelesInHaplotype = false);
     void removePreviousAlleles(vector<Allele*>& alleles, long int position);
-    void removeCappedAlleles(vector<Allele*>& alleles, long int position);
+    void removeCoverageSkippedAlleles(vector<Allele*>& alleles, long int position);
     void removeRegisteredAlignmentsOverlappingPosition(long unsigned int pos);
     void removeFilteredAlleles(vector<Allele*>& alleles);
     void removeDuplicateAlleles(Samples& samples, map<string, vector<Allele*> >& alleleGroups,

--- a/src/AlleleParser.h
+++ b/src/AlleleParser.h
@@ -195,7 +195,8 @@ public:
 
     vector<Allele*> registeredAlleles;
     map<long unsigned int, deque<RegisteredAlignment> > registeredAlignments;
-    set<long int> coverageCappedPositions;
+    set<long unsigned int> coverageCappedPositions;
+    map<long unsigned int, long unsigned int> coverage;
     map<int, map<long int, vector<Allele> > > inputVariantAlleles; // all variants present in the input VCF, as 'genotype' alleles
     pair<int, long int> nextInputVariantPosition(void);
     void getInputVariantsInRegion(string& seq, long start = 0, long end = 0);
@@ -253,6 +254,7 @@ public:
                                      bool getAllAllelesInHaplotype = false);
     void removePreviousAlleles(vector<Allele*>& alleles, long int position);
     void removeCappedAlleles(vector<Allele*>& alleles, long int position);
+    void removeRegisteredAlignmentsOverlappingPosition(long unsigned int pos);
     void removeFilteredAlleles(vector<Allele*>& alleles);
     void removeDuplicateAlleles(Samples& samples, map<string, vector<Allele*> >& alleleGroups,
                                 int allowedAlleleTypes, int haplotypeLength, Allele& refallele);

--- a/src/AlleleParser.h
+++ b/src/AlleleParser.h
@@ -195,6 +195,7 @@ public:
 
     vector<Allele*> registeredAlleles;
     map<long unsigned int, deque<RegisteredAlignment> > registeredAlignments;
+    set<long int> coverageCappedPositions;
     map<int, map<long int, vector<Allele> > > inputVariantAlleles; // all variants present in the input VCF, as 'genotype' alleles
     pair<int, long int> nextInputVariantPosition(void);
     void getInputVariantsInRegion(string& seq, long start = 0, long end = 0);
@@ -251,6 +252,7 @@ public:
                                      int haplotypeLength = 1,
                                      bool getAllAllelesInHaplotype = false);
     void removePreviousAlleles(vector<Allele*>& alleles, long int position);
+    void removeCappedAlleles(vector<Allele*>& alleles, long int position);
     void removeFilteredAlleles(vector<Allele*>& alleles);
     void removeDuplicateAlleles(Samples& samples, map<string, vector<Allele*> >& alleleGroups,
                                 int allowedAlleleTypes, int haplotypeLength, Allele& refallele);

--- a/src/Makefile
+++ b/src/Makefile
@@ -32,7 +32,7 @@ INCLUDE = -I../src -I../ttmath -I$(VCFLIB_ROOT)/src/ -I$(VCFLIB_ROOT)/smithwater
 all: autoversion ../bin/freebayes ../bin/bamleftalign
 
 static:
-	$(MAKE) CXXFLAGS="$(CXXFLAGS) -static" all
+	$(MAKE) CXXFLAGS="$(CXXFLAGS) -static -static-libstdc++ -static-libgcc -Wl,--allow-multiple-definition" all
 
 debug:
 	$(MAKE) CXXFLAGS="$(CXXFLAGS) -D VERBOSE_DEBUG -g -rdynamic" all

--- a/src/Makefile
+++ b/src/Makefile
@@ -5,6 +5,8 @@
 ################################################################################
 
 # Compiler
+
+CXXFLAGS=-O3 -D_FILE_OFFSET_BITS=64 -g
 CXX=g++ ${CXXFLAGS}
 C=gcc
 
@@ -17,7 +19,6 @@ export LIBFLAGS
 
 # Compiler flags
 
-CFLAGS=-O3 -D_FILE_OFFSET_BITS=64 -g
 #CFLAGS=-O3 -static -D VERBOSE_DEBUG  # enables verbose debugging via --debug2
 
 SEQLIB_ROOT=../SeqLib

--- a/src/Makefile
+++ b/src/Makefile
@@ -26,7 +26,7 @@ TABIX_ROOT=$(VCFLIB_ROOT)/tabixpp
 HTSLIB_ROOT=$(SEQLIB_ROOT)/htslib
 
 LIBS = -lz -llzma -lbz2 -lm -lpthread
-INCLUDE = -I../src -I../ttmath -I$(VCFLIB_ROOT)/src/ -I$(VCFLIB_ROOT)/smithwaterman/ -I$(VCFLIB_ROOT)/multichoose/ -I$(VCFLIB_ROOT)/filevercmp/ -I$(VCFLIB_ROOT)/fastahack/ -I$(HTSLIB_ROOT) -I$(SEQLIB_ROOT) 
+INCLUDE = -I../src -I../ttmath -I$(VCFLIB_ROOT)/src/ -I$(VCFLIB_ROOT)/smithwaterman/ -I$(VCFLIB_ROOT)/multichoose/ -I$(VCFLIB_ROOT)/filevercmp/ -I$(VCFLIB_ROOT)/fastahack/ -I$(HTSLIB_ROOT) -I$(SEQLIB_ROOT)
 #INCLUDE = -I../ttmath -I$(BAMTOOLS_ROOT)/src/ -I$(VCFLIB_ROOT)/src/ -I$(TABIX_ROOT)/ -I$(VCFLIB_ROOT)/smithwaterman/ -I$(VCFLIB_ROOT)/multichoose/ -I$(VCFLIB_ROOT)/filevercmp/ -I$(VCFLIB_ROOT)/fastahack/ -I$(HTSLIB_ROOT) -I$(SEQLIB_ROOT) -I$(SEQLIB_ROOT)/htslib
 
 all: autoversion ../bin/freebayes ../bin/bamleftalign

--- a/src/Parameters.cpp
+++ b/src/Parameters.cpp
@@ -72,6 +72,9 @@ void Parameters::usage(char** argv) {
         << "    # require at least 5 supporting observations to consider a variant" << endl
         << "    freebayes -f ref.fa -C 5 aln.bam >var.vcf" << endl
         << endl
+        << "    # discard alignments overlapping positions where total read depth is greater than 200" << endl
+        << "    freebayes -f ref.fa -g 200 aln.bam >var.vcf" << endl
+        << endl
         << "    # use a different ploidy" << endl
         << "    freebayes -f ref.fa -p 4 aln.bam >var.vcf" << endl
         << endl

--- a/src/Parameters.cpp
+++ b/src/Parameters.cpp
@@ -290,11 +290,12 @@ void Parameters::usage(char** argv) {
         << "                   to use the allele in analysis.  default: 1" << endl
         << "   --min-coverage N" << endl
         << "                   Require at least this coverage to process a site. default: 0" << endl
-        << "   --max-coverage N" << endl
+        << "   --limit-coverage N" << endl
         << "                   Downsample per-sample coverage to this level if greater than this coverage." << endl
         << "                   default: no limit" << endl
-        << "   -g --cap-coverage N" << endl
+        << "   -g --skip-coverage N" << endl
         << "                   Skip processing of alignments overlapping positions with coverage >N." << endl
+        << "                   This filters sites above this coverage, but will also reduce data nearby." << endl
         << "                   default: no limit" << endl
         << endl
         << "population priors:" << endl
@@ -479,8 +480,8 @@ Parameters::Parameters(int argc, char** argv) {
     probContamination = 10e-9;
     //minAltQSumTotal = 0;
     minCoverage = 0;
-    maxCoverage = 0;
-    capCoverage = 0;
+    limitCoverage = 0;
+    skipCoverage = 0;
     debuglevel = 0;
     debug = false;
     debug2 = false;
@@ -552,7 +553,7 @@ Parameters::Parameters(int argc, char** argv) {
             //{"min-alternate-mean-mapq", required_argument, 0, 'k'},
             {"min-alternate-qsum", required_argument, 0, '3'},
             {"min-coverage", required_argument, 0, '!'},
-            {"max-coverage", required_argument, 0, '+'},
+            {"limit-coverage", required_argument, 0, '+'},
             {"cap-coverage", required_argument, 0, 'g'},
             {"genotype-qualities", no_argument, 0, '='},
             {"variant-input", required_argument, 0, '@'},
@@ -688,18 +689,18 @@ Parameters::Parameters(int argc, char** argv) {
             }
             break;
 
-            // -+ --max-coverage
+            // -+ --limit-coverage
         case '+':
-            if (!convert(optarg, maxCoverage)) {
-                cerr << "could not parse max-coverage" << endl;
+            if (!convert(optarg, limitCoverage)) {
+                cerr << "could not parse limit-coverage" << endl;
                 exit(1);
             }
             break;
 
-            // -g --cap-coverage
+            // -g --skip-coverage
         case 'g':
-            if (!convert(optarg, capCoverage)) {
-                cerr << "could not parse cap-coverage" << endl;
+            if (!convert(optarg, skipCoverage)) {
+                cerr << "could not parse skip-coverage" << endl;
                 exit(1);
             }
             break;

--- a/src/Parameters.cpp
+++ b/src/Parameters.cpp
@@ -291,7 +291,13 @@ void Parameters::usage(char** argv) {
         << "   --min-coverage N" << endl
         << "                   Require at least this coverage to process a site. default: 0" << endl
         << "   --max-coverage N" << endl
-        << "                   Do not process sites with greater than this coverage. default: no limit" << endl
+        << "                   Downsample per-sample coverage to this level if greater than this coverage." << endl
+        << "                   default: no limit" << endl
+        << "   -g --cap-coverage N" << endl
+        << "                   Do not process alignments when we have already seen N previous alignments" << endl
+        << "                   with the same ending position. This implements an order-dependent heuristic" << endl
+        << "                   downsampling to limit memory usage in very high coverage regions." << endl
+        << "                   default: no limit" << endl
         << endl
         << "population priors:" << endl
         << endl
@@ -476,6 +482,7 @@ Parameters::Parameters(int argc, char** argv) {
     //minAltQSumTotal = 0;
     minCoverage = 0;
     maxCoverage = 0;
+    capCoverage = 0;
     debuglevel = 0;
     debug = false;
     debug2 = false;
@@ -548,6 +555,7 @@ Parameters::Parameters(int argc, char** argv) {
             {"min-alternate-qsum", required_argument, 0, '3'},
             {"min-coverage", required_argument, 0, '!'},
             {"max-coverage", required_argument, 0, '+'},
+            {"cap-coverage", required_argument, 0, 'g'},
             {"genotype-qualities", no_argument, 0, '='},
             {"variant-input", required_argument, 0, '@'},
             {"only-use-input-alleles", no_argument, 0, 'l'},
@@ -573,7 +581,7 @@ Parameters::Parameters(int argc, char** argv) {
     while (true) {
 
         int option_index = 0;
-        c = getopt_long(argc, argv, "hcO4ZKjH[0diN5a)Ik=wl6#uVXJY:b:G:M:x:@:A:f:t:r:s:v:n:B:p:m:q:R:Q:U:$:e:T:P:D:^:S:W:F:C:&:L:8z:1:3:E:7:2:9:%:_:,:(:!:+:",
+        c = getopt_long(argc, argv, "hcO4ZKjH[0diN5a)Ik=wl6#uVXJY:b:G:M:x:@:A:f:t:r:s:v:n:B:p:m:q:R:Q:U:$:e:T:P:D:^:S:W:F:C:&:L:8z:1:3:E:7:2:9:%:_:,:(:!:+:g:",
                         long_options, &option_index);
 
         if (c == -1) // end of options
@@ -686,6 +694,14 @@ Parameters::Parameters(int argc, char** argv) {
         case '+':
             if (!convert(optarg, maxCoverage)) {
                 cerr << "could not parse max-coverage" << endl;
+                exit(1);
+            }
+            break;
+
+            // -g --cap-coverage
+        case 'g':
+            if (!convert(optarg, capCoverage)) {
+                cerr << "could not parse cap-coverage" << endl;
                 exit(1);
             }
             break;

--- a/src/Parameters.cpp
+++ b/src/Parameters.cpp
@@ -294,9 +294,7 @@ void Parameters::usage(char** argv) {
         << "                   Downsample per-sample coverage to this level if greater than this coverage." << endl
         << "                   default: no limit" << endl
         << "   -g --cap-coverage N" << endl
-        << "                   Do not process alignments when we have already seen N previous alignments" << endl
-        << "                   with the same ending position. This implements an order-dependent heuristic" << endl
-        << "                   downsampling to limit memory usage in very high coverage regions." << endl
+        << "                   Skip processing of alignments overlapping positions with coverage >N." << endl
         << "                   default: no limit" << endl
         << endl
         << "population priors:" << endl

--- a/src/Parameters.h
+++ b/src/Parameters.h
@@ -121,6 +121,7 @@ public:
     int minAltTotal;             // -G --min-alternate-total
     int minCoverage;             // -! --min-coverage
     int maxCoverage;             // -+ --max-coverage
+    int capCoverage;
     int debuglevel;              // -d --debug increments
     bool debug; // set if debuglevel >=1
     bool debug2; // set if debuglevel >=2

--- a/src/Parameters.h
+++ b/src/Parameters.h
@@ -120,8 +120,8 @@ public:
     int minAltCount;             // -C --min-alternate-count
     int minAltTotal;             // -G --min-alternate-total
     int minCoverage;             // -! --min-coverage
-    int maxCoverage;             // -+ --max-coverage
-    int capCoverage;
+    int limitCoverage;           // -+ --limit-coverage
+    int skipCoverage;            // -g --skip-coverage
     int debuglevel;              // -d --debug increments
     bool debug; // set if debuglevel >=1
     bool debug2; // set if debuglevel >=2

--- a/src/freebayes.cpp
+++ b/src/freebayes.cpp
@@ -106,7 +106,7 @@ int main (int argc, char *argv[]) {
         out << parser->variantCallFile.header << endl;
     }
 
-    if (0 < parameters.maxCoverage) {
+    if (0 < parameters.limitCoverage) {
         srand(13);
     }
 
@@ -157,7 +157,7 @@ int main (int argc, char *argv[]) {
             } else if (parameters.onlyUseInputAlleles) {
                 DEBUG("no input alleles, but using only input alleles for analysis, skipping position");
                 skip = true;
-            } else if (0 < parameters.maxCoverage) {
+            } else if (0 < parameters.limitCoverage) {
                 // go through each sample
                 for (Samples::iterator s = samples.begin(); s != samples.end(); ++s) {
                     string sampleName = s->first;
@@ -167,14 +167,14 @@ int main (int argc, char *argv[]) {
                     for (Sample::iterator sg = sample.begin(); sg != sample.end(); ++sg) {
                         sampleCoverage += sg->second.size();
                     }
-                    if (sampleCoverage <= parameters.maxCoverage) {
+                    if (sampleCoverage <= parameters.limitCoverage) {
                         continue;
                     }
 
-                    DEBUG("coverage " << sampleCoverage << " for sample " << sampleName << " was > " << parameters.maxCoverage << ", so we will remove " << (sampleCoverage - parameters.maxCoverage) << " genotypes");
+                    DEBUG("coverage " << sampleCoverage << " for sample " << sampleName << " was > " << parameters.limitCoverage << ", so we will remove " << (sampleCoverage - parameters.limitCoverage) << " genotypes");
                     vector<string> genotypesToErase;
                     do {
-                        double probRemove = (sampleCoverage - parameters.maxCoverage) / (double)sampleCoverage;
+                        double probRemove = (sampleCoverage - parameters.limitCoverage) / (double)sampleCoverage;
                         vector<string> genotypesToErase;
                         // iterate through the genotypes
                         for (Sample::iterator sg = sample.begin(); sg != sample.end(); ++sg) {
@@ -182,7 +182,7 @@ int main (int argc, char *argv[]) {
                             // iterate through each allele
                             for (int alleleIndex = 0; alleleIndex < sg->second.size(); alleleIndex++) {
                                 // only if we have more alleles to remove
-                                if (parameters.maxCoverage < sampleCoverage) {
+                                if (parameters.limitCoverage < sampleCoverage) {
                                     double r = rand() / (double)RAND_MAX;
                                     if (r < probRemove) { // skip over this allele
                                         sampleCoverage--;
@@ -205,7 +205,7 @@ int main (int argc, char *argv[]) {
                         for (vector<string>::iterator gt = genotypesToErase.begin(); gt != genotypesToErase.end(); ++gt) {
                             sample.erase(*gt);
                         }
-                    } while (parameters.maxCoverage < sampleCoverage);
+                    } while (parameters.limitCoverage < sampleCoverage);
                     sampleCoverage = 0;
                     for (Sample::iterator sg = sample.begin(); sg != sample.end(); ++sg) {
                         sampleCoverage += sg->second.size();

--- a/test/t/01_call_variants.t
+++ b/test/t/01_call_variants.t
@@ -7,7 +7,7 @@ PATH=../bin:$PATH # for freebayes
 PATH=../scripts:$PATH # for freebayes-parallel
 PATH=../vcflib/bin:$PATH # for vcf binaries used by freebayes-parallel
 
-plan tests 23
+plan tests 24
 
 is $(echo "$(comm -12 <(cat tiny/NA12878.chr22.tiny.giab.vcf | grep -v "^#" | cut -f 2 | sort) <(freebayes -f tiny/q.fa tiny/NA12878.chr22.tiny.bam | grep -v "^#" | cut -f 2 | sort) | wc -l) >= 13" | bc) 1 "variant calling recovers most of the GiAB variants in a test region"
 

--- a/test/t/01_call_variants.t
+++ b/test/t/01_call_variants.t
@@ -7,7 +7,7 @@ PATH=../bin:$PATH # for freebayes
 PATH=../scripts:$PATH # for freebayes-parallel
 PATH=../vcflib/bin:$PATH # for vcf binaries used by freebayes-parallel
 
-plan tests 21
+plan tests 23
 
 is $(echo "$(comm -12 <(cat tiny/NA12878.chr22.tiny.giab.vcf | grep -v "^#" | cut -f 2 | sort) <(freebayes -f tiny/q.fa tiny/NA12878.chr22.tiny.bam | grep -v "^#" | cut -f 2 | sort) | wc -l) >= 13" | bc) 1 "variant calling recovers most of the GiAB variants in a test region"
 
@@ -116,3 +116,6 @@ is $(freebayes -f tiny/q.fa -F 0.2 tiny/NA12878.chr22.tiny.bam --gvcf --gvcf-chu
 samtools view -h tiny/NA12878.chr22.tiny.bam | sed s/NA12878D_HiSeqX_R1.fastq.gz/222.NA12878D_HiSeqX_R1.fastq.gz/ | sed s/SM:1/SM:2/ >x.sam
 is $(freebayes -f tiny/q.fa -F 0.2 tiny/NA12878.chr22.tiny.bam x.sam -A <(echo 1 8; echo 2 13) | grep 'AN=21' | wc -l) 19 "the CNV map may be used to specify per-sample copy numbers"
 rm -f x.sam
+
+is $(freebayes -f tiny/q.fa -g 30 tiny/NA12878.chr22.tiny.bam | grep -v '^#' | wc -l) 27 "freebayes makes the expected number of calls when capping coverage"
+is $(freebayes -f tiny/q.fa -g 30 tiny/NA12878.chr22.tiny.bam | vcfkeepinfo - DP | vcf2tsv | cut -f 8 | tail -n+2 | awk '$1 <= 30 { print }' | wc -l) 27 "all coverage capped calls are below the coverage threshold"


### PR DESCRIPTION
This implements a new filter on the input of freebayes, `--skip-coverage`.

We throw out any alignments that overlap a position exceeding the given threshold. This is meant to speed processing through regions of very high coverage.

Note that `--max-coverage` is actually a downsampling routine, and doesn't have the desired effect in this case. It will limit computational costs in some sense though. This PR renames it to `--limit-coverage` in hopes of avoiding confusion. `--max-coverage` no longer exists, as the name is related to several confused interpretations.