### PR TITLE
can we get away without sorting and removing "non-unique" alleles?

### DIFF
--- a/src/AlleleParser.cpp
+++ b/src/AlleleParser.cpp
@@ -2881,8 +2881,6 @@ bool AlleleParser::toNextPosition(void) {
     // remove past registered alleles
     DEBUG2("marking previous alleles as processed and removing from registered alleles");
     removePreviousAlleles(registeredAlleles, currentPosition);
-    sort(registeredAlleles.begin(), registeredAlleles.end());
-    registeredAlleles.erase(unique(registeredAlleles.begin(), registeredAlleles.end()), registeredAlleles.end());
 
     // if we have alignments which ended at the previous base, erase them and their alleles
     DEBUG2("erasing old registered alignments");


### PR DESCRIPTION
This should reduce runtime by a significant amount, maybe almost half, in some workflows. I'm seeing this helping a bit in longer data. I need to check if there might be a reason to keep this code, but it doesn't seem there is because alleles are only generated once, and are otherwise "fit" to haplotypes without duplication.