### PR TITLE
CNV-map bug fix and speed-up

### DIFF
--- a/src/CNV.cpp
+++ b/src/CNV.cpp
@@ -64,7 +64,7 @@ int CNVMap::ploidy(string const& sample, string const& seq, long int position) {
                 int copyNumber = i->second;
                 if (range.first <= position && range.second > position) {
                     return copyNumber;
-                } else if (position > range.first && position > range.second) {
+                } else if (position < range.first) {
                     // we've passed any potential matches in this sequence, and the map
                     // is sorted by pair, so we don't have any matching ranges
                     break;

--- a/src/CNV.h
+++ b/src/CNV.h
@@ -8,11 +8,13 @@
 #include <vector>
 #include <utility>
 #include <stdlib.h>
+#include <algorithm>
+#include <tuple>
 #include "split.h"
 
 using namespace std;
 
-typedef map<string, map<string, map<pair<long int, long int>, int> > > SampleSeqCNVMap;
+typedef map<string, map<string, vector<tuple<long int, long int, int> > > > SampleSeqCNVMap;
 
 class CNVMap {
 


### PR DESCRIPTION
Current version has a bug: CNV map will not work with more than 1 entry per chromosome per sample.
Suppose the CNV-map looks like this:
```
chr1    0  100  sample1  4
chr1  100  200  sample1  6
```
All positions after position 100 will break on the first iteration and will get the default ploidy instead of 6.