### PR TITLE
Set pipefail and errors for freebayes parallel

### DIFF
--- a/scripts/freebayes-parallel
+++ b/scripts/freebayes-parallel
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -euo pipefail
+
 if [ $# -lt 3 ];
 then
     echo "usage: $0 [regions file] [ncpus] [freebayes arguments]"


### PR DESCRIPTION
If freebayes fails (for example, https://github.com/freebayes/freebayes/issues/831), `freebayes-parallel` should also fail. This should help catch any errors and raise them. Setting these flags is also a good practice for bash scripts.