### PR TITLE
Enhance fasta_generate_regions.py for targeted region specification to enable job recovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,8 +158,15 @@ Example freebayes-parallel operation (use 36 cores in this case):
     freebayes-parallel <(fasta_generate_regions.py ref.fa.fai 100000) 36 \
         -f ref.fa aln.bam > var.vcf
 
+**The `fasta_generate_regions.py` utility now supports specifying specific chromosome regions for targeted chunking.**
+
+Example using the new region specification feature:
+
+    freebayes-parallel <(fasta_generate_regions.py ref.fa.fai 100000 --chromosomes 2:85284353- 3:100000-200000) 36 \
+        -f ref.fa aln.bam > var.vcf
+    
 Note that any of the above examples can be made parallel by using the
-scripts/freebayes-parallel script.  If you find freebayes to be slow, you
+scripts/freebayes-parallel script. If you find freebayes to be slow, you
 should probably be running it in parallel using this script to run on a single
 host, or generating a series of scripts, one per region, and run them on a
 cluster. Be aware that the freebayes-parallel script contains calls to other programs using relative paths from the scripts subdirectory; the easiest way to ensure a successful run is to invoke the freebayes-parallel script from within the scripts subdirectory.


### PR DESCRIPTION
Description
This pull request introduces a crucial enhancement to scripts/fasta_generate_regions.py, directly addressing issues related to job failure and data loss in production environments.

Motivation: I recently experienced a server failure during a long-running FreeBayes job. Because the original script generated regions starting from 0 for all selected chromosomes, the entire analysis had to be restarted from the beginning, leading to significant wasted compute time and resources.

Solution (Key Changes): This update modifies the --chromosomes argument to accept explicit region specifications (e.g., 2:85284353- or X:100-2000).

Enables Job Resumption: Users can now generate chunks precisely starting from the failure point of a previous run (e.g., chrN:POS-), allowing the parallel job to resume exactly where it left off.

Targeted Analysis: Provides flexibility to focus on specific genomic loci or exclude known problematic regions without modifying the entire FASTA index.

This change greatly improves the resilience and efficiency of large-scale FreeBayes parallelization workflows, ensuring that server instability or job crashes do not result in complete analysis restarts.